### PR TITLE
fix(dpi): preserve mixed-DPI placement across restart

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,9 @@ pub struct FenceCfg {
     pub y: i32,
     pub w: i32,
     pub h: i32,
+    /// 保存该物理窗口矩形时的窗口 DPI。0 表示旧配置未记录。
+    #[serde(default)]
+    pub dpi: u32,
     #[serde(default = "default_opacity")]
     pub opacity: f32,
     /// 图标尺寸(旧版存于栅栏上;现由 Config.icon 全局统一。保留字段仅用于一次性迁移)
@@ -38,6 +41,7 @@ impl Default for FenceCfg {
             y: 0,
             w: 260,
             h: 340,
+            dpi: 96,
             opacity: default_opacity(),
             icon: default_icon(),
         }
@@ -66,8 +70,10 @@ pub struct Config {
     /// 全局图标尺寸(逻辑像素,默认 32)
     #[serde(default = "default_icon")]
     pub icon: u32,
-    /// 配置格式版本:>=2 表示栅栏 x/y/w/h 存逻辑像素(读写边界按 DPI 转换)。
-    /// 缺省/1 = 旧版物理像素,加载后由 normalize_dpi 一次性迁移。
+    /// 配置格式版本:
+    /// - 缺省/1:旧版物理 x/y/w/h,未记录 DPI
+    /// - 2:逻辑 x/y/w/h,启动时统一乘系统 DPI
+    /// - 3:物理 x/y/w/h + 每栅栏保存时 DPI
     #[serde(default)]
     pub version: u32,
 }
@@ -81,28 +87,89 @@ impl Default for Config {
             autostart: false,
             vault_dir: None,
             icon: default_icon(),
-            version: 2,
+            version: 3,
         }
     }
 }
 
-/// 把磁盘配置转成本会话的物理像素布局:
-/// - 旧版(version < 2)配置是物理像素 → 原样保留(下次保存转逻辑像素,一次性迁移,现有布局零变化)。
-/// - v2+ 配置是逻辑像素 → 按当前系统 DPI 乘回物理像素。
+/// 把磁盘配置迁移为 v3 的物理像素布局:
+/// - v1 是物理像素且没有 DPI,保留未知值 0,由窗口创建后用实际 DPI 接管。
+/// - v2 的四个字段都是逻辑像素,按旧规则乘系统 DPI 做一次性尽力迁移。
+/// - v3 已是物理像素,保持 x/y 不变;窗口创建后再按保存 DPI 调整 w/h。
 /// 调用点:进程启动 load() 之后、MENU_RELOAD 之后。
 pub fn normalize_dpi(c: &mut Config) {
-    if c.version >= 2 {
-        let s = crate::fence::dpi_scale();
-        if s != 1.0 {
-            for f in &mut c.fences {
+    let system_dpi = (crate::fence::dpi_scale() * 96.0).round() as u32;
+    normalize_dpi_with_system(c, system_dpi);
+}
+
+fn normalize_dpi_with_system(c: &mut Config, system_dpi: u32) {
+    if c.version == 2 {
+        let s = system_dpi as f32 / 96.0;
+        for f in &mut c.fences {
+            if s != 1.0 {
                 f.x = (f.x as f32 * s).round() as i32;
                 f.y = (f.y as f32 * s).round() as i32;
                 f.w = (f.w as f32 * s).round() as i32;
                 f.h = (f.h as f32 * s).round() as i32;
             }
+            f.dpi = system_dpi;
         }
     }
-    c.version = 2;
+    c.version = 3;
+}
+
+/// 保持逻辑尺寸不变,把一个物理像素长度从保存 DPI 换算到当前窗口 DPI。
+pub fn scale_extent_for_dpi(value: i32, saved_dpi: u32, current_dpi: u32) -> i32 {
+    // v1 没有保存 DPI;把未知值视为当前窗口 DPI可原样保留旧物理尺寸。
+    let from = if saved_dpi == 0 { current_dpi } else { saved_dpi }.max(1) as f64;
+    ((value as f64 * current_dpi.max(1) as f64) / from).round() as i32
+}
+
+#[cfg(test)]
+mod dpi_tests {
+    use super::*;
+
+    fn fixture(version: u32, x: i32, w: i32, dpi: u32) -> Config {
+        Config {
+            version,
+            fences: vec![FenceCfg {
+                x,
+                w,
+                dpi,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn v1_physical_geometry_stays_physical_and_dpi_remains_unknown() {
+        let mut c = fixture(1, 2400, 260, 0);
+        normalize_dpi_with_system(&mut c, 192);
+        assert_eq!((c.fences[0].x, c.fences[0].w, c.fences[0].dpi), (2400, 260, 0));
+        assert_eq!(c.version, 3);
+    }
+
+    #[test]
+    fn v2_logical_geometry_uses_the_legacy_system_dpi_migration() {
+        let mut c = fixture(2, 1000, 260, 0);
+        normalize_dpi_with_system(&mut c, 192);
+        assert_eq!((c.fences[0].x, c.fences[0].w, c.fences[0].dpi), (2000, 520, 192));
+        assert_eq!(c.version, 3);
+    }
+
+    #[test]
+    fn v3_physical_geometry_is_not_rescaled_by_system_dpi() {
+        let mut c = fixture(3, 2000, 520, 192);
+        normalize_dpi_with_system(&mut c, 96);
+        assert_eq!((c.fences[0].x, c.fences[0].w, c.fences[0].dpi), (2000, 520, 192));
+    }
+
+    #[test]
+    fn unknown_saved_dpi_preserves_v1_extent() {
+        assert_eq!(scale_extent_for_dpi(260, 0, 192), 260);
+        assert_eq!(scale_extent_for_dpi(520, 192, 144), 390);
+    }
 }
 
 pub fn config_dir() -> PathBuf {

--- a/src/fence.rs
+++ b/src/fence.rs
@@ -83,7 +83,7 @@ pub fn dpi_scale() -> f32 {
 }
 /// 窗口所在显示器 DPI 缩放因子(Per-Monitor):
 /// 副屏与主屏缩放不同时,按窗口实际所在屏缩放,而非系统(主屏)DPI
-fn window_dpi(hwnd: HWND) -> f32 {
+pub fn window_dpi(hwnd: HWND) -> f32 {
     unsafe { windows::Win32::UI::HiDpi::GetDpiForWindow(hwnd) as f32 / 96.0 }.max(1.0)
 }
 pub fn title_h(d: f32) -> i32 {
@@ -1070,6 +1070,7 @@ unsafe extern "system" fn fence_wndproc(
                     f.cfg.y = rect.top;
                     f.cfg.w = nw;
                     f.cfg.h = nh;
+                    f.cfg.dpi = newdpi;
                     unsafe {
                         let _ = SetWindowPos(
                             hwnd,
@@ -1334,19 +1335,15 @@ pub fn settle_fence(g: &mut crate::Global, idx: usize) {
     crate::config::save(&g.config);
 }
 
-/// 把运行时栅栏(物理像素)转成持久化配置(逻辑像素):
-/// x/y/w/h ÷ f.dpi,使同一份配置在不同 DPI 屏幕上打开时"逻辑布局一致"
-/// (物理尺寸成比例,图标/字体/格距保持一致)。
+/// 持久化运行时物理矩形及其窗口 DPI。
+/// 屏幕 x/y 不能除以窗口 DPI:它们位于跨显示器的全局坐标空间,
+/// 混合缩放时再统一乘系统 DPI不可逆。启动恢复只换算 w/h。
 pub fn config_snapshot(fences: &[Fence]) -> Vec<FenceCfg> {
     fences
         .iter()
         .map(|f| {
             let mut c = f.cfg.clone();
-            let s = f.dpi.max(1.0);
-            c.x = (c.x as f32 / s).round() as i32;
-            c.y = (c.y as f32 / s).round() as i32;
-            c.w = (c.w as f32 / s).round() as i32;
-            c.h = (c.h as f32 / s).round() as i32;
+            c.dpi = (f.dpi.max(1.0) * 96.0).round() as u32;
             c
         })
         .collect()

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,11 +138,16 @@ pub fn create_fence(g: &mut Global, mut cfg: FenceCfg) -> u32 {
         cfg.x = (sw - (320.0 * ms) as i32 - (20.0 * ms) as i32 - (n as i32 % 5) * (30.0 * ms) as i32).max(0);
         cfg.y = ((80.0 * ms) as i32 + (n as i32 % 5) * (40.0 * ms) as i32).min((sh - (400.0 * ms) as i32).max(0));
     }
-    if cfg.w < fence::min_w(ms) {
-        cfg.w = fence::min_w(ms);
-    }
-    if cfg.h < fence::min_h(ms) {
-        cfg.h = fence::min_h(ms);
+    // 恢复配置时先按保存 DPI 钳制;窗口创建后再按实际窗口 DPI 做最终换算。
+    // 若这里使用系统 DPI,主屏 200% + 副屏 100% 会在创建副屏窗口前把尺寸错误放大。
+    if cfg.dpi != 0 {
+        let saved_scale = cfg.dpi as f32 / 96.0;
+        if cfg.w < fence::min_w(saved_scale) {
+            cfg.w = fence::min_w(saved_scale);
+        }
+        if cfg.h < fence::min_h(saved_scale) {
+            cfg.h = fence::min_h(saved_scale);
+        }
     }
 
     // 不挂 Progman(分层窗口+高 alpha+Progman 父窗口会触发 DWM 命中测试 bug,
@@ -159,6 +164,77 @@ pub fn create_fence(g: &mut Global, mut cfg: FenceCfg) -> u32 {
     g.droptargets.push(it);
 
     let mut f = Fence::new(cfg, hwnd);
+    // v3 持久化保留物理屏幕位置,仅按保存时 DPI → 当前窗口 DPI 换算尺寸。
+    // 不能用系统 DPI 统一恢复:混合缩放多屏会把副屏窗口漂回主屏坐标。
+    let saved_dpi = f.cfg.dpi;
+    let saved_w = f.cfg.w;
+    let saved_h = f.cfg.h;
+    let mut current_dpi = (f.dpi * 96.0).round() as u32;
+    let mut converged = false;
+    // 尺寸变化可能让跨屏窗口的主显示器切换;重新读取实际 DPI,最多再换算一次。
+    for _ in 0..2 {
+        f.dpi = current_dpi as f32 / 96.0;
+        let restored_w = config::scale_extent_for_dpi(saved_w, saved_dpi, current_dpi)
+            .max(fence::min_w(f.dpi));
+        let restored_h = config::scale_extent_for_dpi(saved_h, saved_dpi, current_dpi)
+            .max(fence::min_h(f.dpi));
+        if restored_w != f.cfg.w || restored_h != f.cfg.h {
+            unsafe {
+                let _ = SetWindowPos(
+                    hwnd,
+                    None,
+                    f.cfg.x,
+                    f.cfg.y,
+                    restored_w,
+                    restored_h,
+                    SWP_NOZORDER | SWP_NOACTIVATE,
+                );
+            }
+            f.cfg.w = restored_w;
+            f.cfg.h = restored_h;
+        }
+        let observed_dpi = (fence::window_dpi(hwnd) * 96.0).round() as u32;
+        if observed_dpi == current_dpi {
+            converged = true;
+            break;
+        }
+        current_dpi = observed_dpi;
+    }
+    if !converged {
+        // 窗口卡在混合 DPI 屏幕边界时可能 A→B→A 振荡。选择当前实际显示器,
+        // 按其 DPI 计算尺寸并把窗口完整钳进工作区,得到确定的终止状态。
+        f.dpi = current_dpi as f32 / 96.0;
+        let wa = utils::work_area(hwnd);
+        let restored_w = config::scale_extent_for_dpi(saved_w, saved_dpi, current_dpi)
+            .max(fence::min_w(f.dpi))
+            .min(wa.right - wa.left);
+        let restored_h = config::scale_extent_for_dpi(saved_h, saved_dpi, current_dpi)
+            .max(fence::min_h(f.dpi))
+            .min(wa.bottom - wa.top);
+        let x = f.cfg.x.clamp(wa.left, (wa.right - restored_w).max(wa.left));
+        let y = f.cfg.y.clamp(wa.top, (wa.bottom - restored_h).max(wa.top));
+        unsafe {
+            let _ = SetWindowPos(
+                hwnd,
+                None,
+                x,
+                y,
+                restored_w,
+                restored_h,
+                SWP_NOZORDER | SWP_NOACTIVATE,
+            );
+        }
+    }
+    // 边界窗口可能在两种尺寸间切换主显示器。无论是否收敛,最终都以
+    // Win32 的实际 DPI 和窗口矩形为准,避免 cfg.dpi、f.dpi、w/h 互相矛盾。
+    f.dpi = fence::window_dpi(hwnd);
+    let mut final_rect = RECT::default();
+    unsafe { let _ = GetWindowRect(hwnd, &mut final_rect); }
+    f.cfg.x = final_rect.left;
+    f.cfg.y = final_rect.top;
+    f.cfg.w = (final_rect.right - final_rect.left).max(1);
+    f.cfg.h = (final_rect.bottom - final_rect.top).max(1);
+    f.cfg.dpi = (f.dpi * 96.0).round() as u32;
     fence::refresh_entries(&mut f, &config::vault_dir(&g.config));
     fence::render_fence(&mut g.icons, g.config.ghost_mode, &mut f);
     let id = f.cfg.id;
@@ -462,6 +538,7 @@ fn dispatch_menu(cmd: u32) {
                         y: (100.0 * s) as i32 + (g.fences.len() as i32 % 5) * (40.0 * s) as i32,
                         w: (280.0 * s) as i32,
                         h: (340.0 * s) as i32,
+                        dpi: (96.0 * s).round() as u32,
                         opacity: 0.74,
                         icon: 32,
                     };
@@ -505,6 +582,7 @@ fn dispatch_menu(cmd: u32) {
                         y: (100.0 * s) as i32 + (g.fences.len() as i32 % 5) * (40.0 * s) as i32,
                         w: (260.0 * s) as i32,
                         h: (340.0 * s) as i32,
+                        dpi: (96.0 * s).round() as u32,
                         opacity: 0.74,
                         icon: 32,
                     };
@@ -759,6 +837,7 @@ fn main() {
                 y: (100.0 * s) as i32,
                 w: (260.0 * s) as i32,
                 h: (340.0 * s) as i32,
+                dpi: (96.0 * s).round() as u32,
                 opacity: 0.74,
                 icon: 32,
             };


### PR DESCRIPTION
Fixes #1

## 问题与根因

当前 v2 配置在保存时把每个 fence 的 `x/y/w/h` 除以该窗口 DPI，但加载时统一乘系统/主屏 DPI。`x/y` 实际属于跨显示器的虚拟桌面物理坐标；混合缩放时，两次变换的 DPI 基准不同，因而不可逆。

最小示例（主屏 100% / 96 DPI，右侧副屏 200% / 192 DPI）：

```text
副屏实际矩形： (2000, 200, 520, 680)
v2 保存：       ÷ 2.0 → (1000, 100, 260, 340)
重启加载：      × 1.0 → (1000, 100, 260, 340)
```

结果是 fence 可能漂回主屏且宽高减半；主屏 200% + 副屏 100% 时则可能反向放大。完整定位、双向复现及 Release 现状见 #1。

## 修复内容

- 配置格式升级为 v3，每个 fence 持久化物理 `x/y/w/h` 及保存时的窗口 DPI；
- 恢复时保持全局物理 `x/y`，只将 `w/h` 从保存 DPI 换算到实际 `GetDpiForWindow`；
- 初次 `SetWindowPos` 后重新读取窗口 DPI，处理尺寸变化导致窗口主显示器改变的情况；
- 两轮仍在不同 DPI 显示器边界振荡时，按最后观测 DPI 计算尺寸，将窗口完整钳入当前工作区，然后以 `GetDpiForWindow` + `GetWindowRect` 同步最终运行态和持久化态；
- `WM_DPICHANGED` 同步保存新的 fence DPI；
- 新建 fence 同时记录创建时 DPI；
- 增加配置迁移与尺寸换算单元测试。

迁移语义：

| 配置版本 | 原语义 | 迁移到 v3 |
| --- | --- | --- |
| 缺省 / v1 | 物理矩形，未记录 DPI | 保持矩形；未知 DPI 在窗口创建后视为当前窗口 DPI，避免首次迁移缩放 |
| v2 | 按旧实现保存的逻辑矩形 | 先按旧系统 DPI 规则尽力恢复为物理矩形，并记录该 DPI |
| v3 | 物理矩形 + 每窗口 DPI | `x/y` 原样保留，`w/h` 按保存 DPI → 当前窗口 DPI 换算 |

## 预期效果

- 同一显示拓扑下，混合 DPI 多屏重启不再因为窗口 DPI 与主屏 DPI 不同而二次缩放全局坐标；
- 显示器 DPI 改变时，位置仍保持物理坐标语义，宽高保持逻辑尺寸；
- 保留现有启动磁吸、最小尺寸、`WM_DPICHANGED` 与显示器工作区 clamp 行为；
- v1 / v2 用户配置可一次性迁移，不要求手工删除配置。

## 验证

基线：`BaldwinShu/FeatherFence@c856a79560129967f72d984306cc8faeabe02327`

环境：

```text
Host: macOS 26.2, aarch64-apple-darwin
rustc: 1.95.0 (59807616e 2026-04-14)
cargo: 1.95.0 (f2d3ce0bd 2026-03-21)
Windows check target: x86_64-pc-windows-gnu
```

执行结果：

- 无 GUI DPI 回归夹具：8 passed / 0 failed，连续运行 5 轮结果一致；夹具直接包含本次真实 `src/config.rs`，其中 4 项为本 PR 内联单元测试，另 4 项覆盖 100%/200% 重启与保存 DPI → 当前 DPI 换算；
- `cargo check --all-targets --target x86_64-pc-windows-gnu`：完成，无编译错误（仓库原有 warning 仍存在，本 PR 未扩大范围处理）；
- `git diff --check`：通过；
- 独立 Spec 与 Win32/序列化审查：最终均无 blocker；审查中发现并修复了 v1 迁移缩放、初始 HWND DPI 竞态及 96→192→96 边界振荡问题。

## 合并前建议的 Windows 运行时矩阵

- Windows 10 / 11；
- 单屏 100%、150%、200%；
- 双屏 100% + 200% 与 200% + 100%；
- 两屏分别创建 fence，退出并重启，检查位置、宽高和文件内容；
- 应用关闭期间修改 DPI 后再启动；
- fence 跨屏、贴边和位于两屏边界时重启；
- v1、v2、v3 配置各验证一次，并确认第二次重启不再迁移。

## 限制

当前开发环境没有真实 Windows 混合 DPI GUI 会话，因此本 PR 不声称已经完成 Win32 运行时 smoke test。现有证据覆盖配置算法、迁移逻辑、Windows 目标编译及独立代码审查；建议维护者合并前执行上面的真实显示器矩阵。

另外，现有 Release `v0.1.0` 指向较早的 `b34c87ceae64ccb4755f9719b7fb6e92814a4956`。本修复合并并完成 Windows 验证后，建议从最新 `main` 重新发布构建产物。
