### PR TITLE
修复：栅栏销毁时停止目录监听线程

### DIFF
--- a/src/fence.rs
+++ b/src/fence.rs
@@ -509,24 +509,13 @@ pub fn fence_menu(hwnd: HWND) {
         let cmd = cmd.0 as u32;
         if cmd == 1001 {
             with_global(|g| {
-                // 先按 hwnd 移除再销毁:DestroyWindow 会同步发 WM_DESTROY 把该栅栏
-                // valid 置 false,若之后才 remove(watchdog 把 !valid 当"被 Explorer 销毁"
-                // 重建回来),列表条目删不掉,watchdog 定时器几秒后就会把栅栏重建回来
-                // = "删除无效"。先移除,WM_DESTROY 里 fence_idx 自然找不到,无副作用。
                 if let Some(idx) = g.fences.iter().position(|f| f.hwnd == hwnd) {
                     if g.config.download_box_id == Some(g.fences[idx].cfg.id) {
                         crate::set_download_enabled(g, false);
                         return;
                     }
-                    let h = g.fences[idx].hwnd;
-                    g.fences.remove(idx);
-                    unsafe {
-                        windows::Win32::System::Ole::RevokeDragDrop(h);
-                        DestroyWindow(h);
-                    }
+                    crate::delete_fence(g, idx);
                 }
-                g.config.fences = config_snapshot(&g.fences);
-                crate::config::save(&g.config);
             });
         } else if (1002..=1004).contains(&cmd) {
             with_global(|g| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,34 @@ pub struct Global {
     /// 拖放 COM 对象,保持存活
     pub droptargets: Vec<windows::Win32::System::Ole::IDropTarget>,
     /// 目录监听线程
-    pub watchers: Vec<watcher::DirWatcher>,
+    pub watchers: Vec<ManagedWatcher>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum WatcherOwner {
+    Process,
+    Fence(u32),
+}
+
+pub struct ManagedWatcher {
+    owner: WatcherOwner,
+    _watcher: watcher::DirWatcher,
+}
+
+impl ManagedWatcher {
+    fn process(watcher: watcher::DirWatcher) -> Self {
+        Self {
+            owner: WatcherOwner::Process,
+            _watcher: watcher,
+        }
+    }
+
+    fn fence(id: u32, watcher: watcher::DirWatcher) -> Self {
+        Self {
+            owner: WatcherOwner::Fence(id),
+            _watcher: watcher,
+        }
+    }
 }
 
 pub struct DownloadCandidate {
@@ -273,7 +300,7 @@ pub fn create_fence(g: &mut Global, mut cfg: FenceCfg) -> u32 {
                 );
             }
         });
-        g.watchers.push(watcher);
+        g.watchers.push(ManagedWatcher::fence(id, watcher));
     }
     sync_config(g);
     id
@@ -283,12 +310,15 @@ pub fn delete_fence(g: &mut Global, idx: usize) {
     if idx >= g.fences.len() {
         return;
     }
-    let f = &g.fences[idx];
+    // 先从全局状态移除，DestroyWindow 同步派发 WM_DESTROY 时就不会把条目标成
+    // “意外失效”并被 watchdog 重建。对应监听器在窗口销毁前停止，避免继续投递刷新。
+    let f = g.fences.remove(idx);
+    g.watchers
+        .retain(|watcher| watcher.owner != WatcherOwner::Fence(f.cfg.id));
     unsafe {
         windows::Win32::System::Ole::RevokeDragDrop(f.hwnd);
         DestroyWindow(f.hwnd);
     }
-    g.fences.remove(idx);
     sync_config(g);
 }
 
@@ -923,6 +953,10 @@ fn dispatch_menu(cmd: u32) {
                 let mut c = config::load();
                 config::normalize_dpi(&mut c);
                 g.config = c;
+                // 保留进程级监听（桌面清扫和 Downloads 接管）；先停止所有栅栏监听，
+                // 避免窗口销毁期间仍收到刷新。
+                g.watchers
+                    .retain(|watcher| watcher.owner == WatcherOwner::Process);
                 // 先销毁全部旧窗口(避免持借用调用 DestroyWindow)
                 let hwnds: Vec<HWND> = g.fences.iter().filter(|f| f.valid).map(|f| f.hwnd).collect();
                 for h in hwnds {
@@ -933,7 +967,6 @@ fn dispatch_menu(cmd: u32) {
                 }
                 g.fences.clear();
                 g.droptargets.clear();
-                g.watchers.clear();
                 for cfg in g.config.fences.clone() {
                     create_fence(g, cfg);
                 }
@@ -1173,7 +1206,7 @@ fn main() {
                     }
                 }
             });
-            g.watchers.push(watcher);
+            g.watchers.push(ManagedWatcher::process(watcher));
         }
         // 下载收纳箱：单独监听 Downloads 目录，避免把桌面所有文件都当下载。
         if let Some(dir) = downloads_dir() {
@@ -1181,7 +1214,7 @@ fn main() {
             let watcher = watcher::spawn_dir_watcher(dir, move |names| {
                 let _ = tx.send(names.clone());
             });
-            g.watchers.push(watcher);
+            g.watchers.push(ManagedWatcher::process(watcher));
         }
         reserve_desktop_icons(g);
     });
@@ -1220,6 +1253,8 @@ fn main() {
     // 清理
     with_global(|g| {
         g.exiting = true;
+        // 先停止所有目录监听，确保清理窗口和 COM/GDI+ 后不再有后台通知。
+        g.watchers.clear();
         config::save(&g.config);
         for f in g.fences.iter() {
             if f.valid {

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,7 +1,10 @@
 // 目录监听:ReadDirectoryChangesW,文件夹门户实时刷新 + 桌面自动归类
 use std::ffi::c_void;
+use std::os::windows::io::AsRawHandle;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Condvar, Mutex};
 use std::thread::JoinHandle;
+use std::time::Duration;
 
 use windows::core::PCWSTR;
 use windows::Win32::Foundation::HANDLE;
@@ -11,21 +14,92 @@ use windows::Win32::Storage::FileSystem::{
     FILE_NOTIFY_CHANGE_DIR_NAME, FILE_NOTIFY_CHANGE_FILE_NAME, FILE_SHARE_DELETE,
     FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
 };
+use windows::Win32::System::IO::CancelSynchronousIo;
 
 use crate::utils::wstr;
 
+#[derive(Default)]
+struct StopSignal {
+    stopped: Mutex<bool>,
+    changed: Condvar,
+}
+
+impl StopSignal {
+    fn is_stopped(&self) -> bool {
+        *self
+            .stopped
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn request_stop(&self) {
+        let mut stopped = self
+            .stopped
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *stopped = true;
+        self.changed.notify_all();
+    }
+
+    /// 可中断的重试等待。返回 true 表示已请求停止。
+    fn wait_timeout(&self, timeout: Duration) -> bool {
+        let stopped = self
+            .stopped
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if *stopped {
+            return true;
+        }
+        let (stopped, _) = self
+            .changed
+            .wait_timeout_while(stopped, timeout, |stopped| !*stopped)
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *stopped
+    }
+}
+
 pub struct DirWatcher {
-    pub thread: Option<JoinHandle<()>>,
+    stop: Arc<StopSignal>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl DirWatcher {
+    /// 停止阻塞中的 ReadDirectoryChangesW 并回收监听线程。可重复调用。
+    pub fn stop(&mut self) {
+        let Some(thread) = self.thread.take() else {
+            return;
+        };
+        self.stop.request_stop();
+
+        // CancelSynchronousIo 只取消调用瞬间已经挂起的同步 I/O。工作线程可能正好
+        // 位于“检查 stop → 发起 ReadDirectoryChangesW”的短窗口内，因此在它退出前
+        // 重试取消；线程每次 I/O 返回后也会检查 stop，不会再次进入阻塞读取。
+        while !thread.is_finished() {
+            unsafe {
+                let _ = CancelSynchronousIo(HANDLE(thread.as_raw_handle()));
+            }
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        let _ = thread.join();
+    }
+}
+
+impl Drop for DirWatcher {
+    fn drop(&mut self) {
+        self.stop();
+    }
 }
 
 pub fn spawn_dir_watcher<F>(dir: PathBuf, notify: F) -> DirWatcher
 where
     F: Fn(Vec<String>) + Send + 'static,
 {
+    let stop = Arc::new(StopSignal::default());
+    let thread_stop = stop.clone();
     let thread = std::thread::spawn(move || {
         let mut handle: Option<HANDLE> = None;
         let mut buf = vec![0u8; 64 * 1024];
-        loop {
+        while !thread_stop.is_stopped() {
             if handle.is_none() {
                 let wdir = wstr(&dir.to_string_lossy());
                 handle = unsafe {
@@ -41,9 +115,14 @@ where
                     .ok()
                 };
                 if handle.is_none() {
-                    std::thread::sleep(std::time::Duration::from_secs(3));
+                    if thread_stop.wait_timeout(Duration::from_secs(3)) {
+                        break;
+                    }
                     continue;
                 }
+            }
+            if thread_stop.is_stopped() {
+                break;
             }
             let h = handle.unwrap();
             let mut returned: u32 = 0;
@@ -59,20 +138,33 @@ where
                     None,
                 )
             };
+            if thread_stop.is_stopped() {
+                break;
+            }
             if ok.is_err() || returned == 0 {
                 // 目录失效,关掉重来
                 unsafe { let _ = windows::Win32::Foundation::CloseHandle(h); }
                 handle = None;
-                std::thread::sleep(std::time::Duration::from_secs(3));
+                if thread_stop.wait_timeout(Duration::from_secs(3)) {
+                    break;
+                }
                 continue;
             }
             let names = parse_notify_names(&buf, returned as usize);
-            if !names.is_empty() {
+            if !names.is_empty() && !thread_stop.is_stopped() {
                 notify(names);
             }
         }
+        if let Some(handle) = handle {
+            unsafe {
+                let _ = windows::Win32::Foundation::CloseHandle(handle);
+            }
+        }
     });
-    DirWatcher { thread: Some(thread) }
+    DirWatcher {
+        stop,
+        thread: Some(thread),
+    }
 }
 
 fn parse_notify_names(buf: &[u8], returned: usize) -> Vec<String> {
@@ -120,6 +212,9 @@ fn parse_notify_names(buf: &[u8], returned: usize) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::parse_notify_names;
+    use super::spawn_dir_watcher;
+    use std::sync::mpsc;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
     use windows::Win32::Storage::FileSystem::FILE_ACTION_RENAMED_NEW_NAME;
 
     #[test]
@@ -133,6 +228,46 @@ mod tests {
             record.extend_from_slice(&ch.to_le_bytes());
         }
         assert_eq!(parse_notify_names(&record, record.len()), ["Notion-7.29.0.msix"]);
+    }
+
+    #[test]
+    fn stopped_watcher_does_not_deliver_later_changes() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "feather-fences-watcher-{}-{nonce}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let (tx, rx) = mpsc::channel();
+        let mut watcher = spawn_dir_watcher(dir.clone(), move |names| {
+            let _ = tx.send(names);
+        });
+
+        // The worker opens the directory asynchronously. Probe until the first
+        // notification proves the watcher is ready instead of relying on sleep.
+        let mut ready = false;
+        for attempt in 0..30 {
+            let name = format!("probe-{attempt}.txt");
+            std::fs::write(dir.join(&name), b"probe").unwrap();
+            if let Ok(names) = rx.recv_timeout(Duration::from_millis(100)) {
+                if names.iter().any(|seen| seen == &name) {
+                    ready = true;
+                    break;
+                }
+            }
+        }
+        assert!(ready, "watcher did not report a change within 3 seconds");
+
+        watcher.stop();
+        while rx.try_recv().is_ok() {}
+        std::fs::write(dir.join("second.txt"), b"second").unwrap();
+        assert!(rx.recv_timeout(Duration::from_millis(250)).is_err());
+
+        std::fs::remove_dir_all(dir).unwrap();
     }
 }
 


### PR DESCRIPTION
## 修改内容

- 为 `DirWatcher` 增加可重复调用的 `stop` 方法和 `Drop` 自动清理。
- 使用 `CancelSynchronousIo` 取消阻塞中的 `ReadDirectoryChangesW`，随后等待监听线程退出。
- 将监听器重试等待改为可中断，并在线程退出时关闭目录句柄。
- 将监听器区分为进程级监听器和具体栅栏的监听器。
- 删除栅栏时停止对应监听器；重新加载配置时停止旧栅栏监听器；程序退出时停止全部监听器。
- 保留桌面清扫与 Downloads 接管两个进程级监听器，适配上游新增的 Downloads 独立监听逻辑。
- 将栅栏右键菜单的删除操作统一交给公共的 `delete_fence` 流程。
- 增加回归测试，验证监听器停止后不会继续上报后续文件变化。

## 问题原因

原实现只保存了监听线程的 `JoinHandle`。清空监听器列表时，丢弃 `JoinHandle` 只会让线程与主线程分离，并不会停止线程；工作线程仍可能一直阻塞在无限循环的 `ReadDirectoryChangesW` 中。

因此，删除栅栏、重新加载配置或退出程序后，旧的监听线程和目录句柄可能继续存活。已经删除的栅栏监听器也可能继续向失效窗口发送刷新消息。

本修改为目录监听器补充了明确的取消和回收流程，并通过所有权信息只停止受影响栅栏的监听器。重新加载配置时会保留桌面清扫和 Downloads 接管等进程级监听器，避免相应功能失效。

## 影响

- 防止删除栅栏后继续收到旧目录通知。
- 确定性地回收监听线程和目录句柄。
- 重新加载配置后继续保持桌面清扫与 Downloads 接管监听。
- 不改变监听器正常运行时的目录通知行为。

## 验证

- 基于最新 `upstream/main` 完成变基和适配。
- `cargo test --all`：7 项测试全部通过。
- 目录监听生命周期回归测试连续运行 5 次：全部通过。
- `cargo check --target x86_64-pc-windows-msvc`：通过。
- 使用 Windows GNU 工具链执行 `cargo build --release`：通过。
