### PR TITLE
性能：优化栅栏翻页渲染并加入分阶段测量

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -201,6 +201,11 @@ mod dpi_tests {
 }
 
 pub fn config_dir() -> PathBuf {
+    if crate::perf::enabled() {
+        if let Some(path) = std::env::var_os("FEATHER_PERF_CONFIG_DIR") {
+            return PathBuf::from(path);
+        }
+    }
     let base = std::env::var_os("APPDATA")
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("."));

--- a/src/fence.rs
+++ b/src/fence.rs
@@ -267,9 +267,10 @@ pub struct Fence {
     pub top_row: f32,
     /// 翻页动画计时器是否在跑
     pub animating: bool,
-    /// 翻页动画已推进帧数 + 起始 top_row(固定时长 ease-out 用)
-    pub anim_frames: u32,
+    /// 翻页动画起始时间 + 起始 top_row(固定时长 ease-out 用)
+    pub anim_started: Instant,
     pub anim_from: f32,
+    perf_anim_remaining: u32,
     /// 滚轮增量累加器(1/120 刻度):触控板/高精度滚轮的小增量先累积,满 120 再翻页
     pub wheel_acc: i32,
     pub hover: Option<usize>,
@@ -300,8 +301,9 @@ impl Fence {
             page: 0,
             top_row: 0.0,
             animating: false,
-            anim_frames: 0,
+            anim_started: Instant::now(),
             anim_from: 0.0,
+            perf_anim_remaining: 0,
             wheel_acc: 0,
             hover: None,
             selected: None,
@@ -499,34 +501,63 @@ pub fn schedule_render(hwnd: HWND) {
 /// 刷新栅栏条目:folder 指定则显示该文件夹;否则显示收纳箱(vault)目录。
 /// 这样拖入文件(handle_drop 把无 folder 的栅栏文件移进 vault)会立即显示,重启后也持久。
 pub fn refresh_entries(f: &mut Fence, vault: &PathBuf) {
+    let profiling = crate::perf::enabled();
+    let total_started = profiling.then(Instant::now);
     let page = f.page;
     let selected_path = f.selected.and_then(|i| f.entries.get(i)).map(|e| e.path.clone());
     f.entries.clear();
     let dir = f.cfg.folder.clone().unwrap_or_else(|| vault.clone());
+    let read_started = profiling.then(Instant::now);
+    let read_time;
+    let mut sort_time = Duration::default();
+    let mut succeeded = false;
     if let Ok(rd) = std::fs::read_dir(&dir) {
+        succeeded = true;
         for e in rd.flatten() {
             let path = e.path();
             let name = e.file_name().to_string_lossy().to_string();
             let is_dir = e.file_type().map(|t| t.is_dir()).unwrap_or(false);
             f.entries.push(Entry { path, name, is_dir });
         }
+        read_time = read_started
+            .map(|started| started.elapsed())
+            .unwrap_or_default();
+        let sort_started = profiling.then(Instant::now);
         f.entries.sort_by(|a, b| {
             b.is_dir
                 .cmp(&a.is_dir)
                 .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
         });
+        sort_time = sort_started
+            .map(|started| started.elapsed())
+            .unwrap_or_default();
+    } else {
+        read_time = read_started
+            .map(|started| started.elapsed())
+            .unwrap_or_default();
     }
     f.selected = selected_path.and_then(|p| f.entries.iter().position(|e| e.path == p));
     f.page = page;
     f.wheel_acc = 0;
     sync_page(f);
+    if let Some(started) = total_started {
+        crate::perf::record_refresh(
+            f.cfg.id,
+            &dir,
+            f.entries.len(),
+            read_time,
+            sort_time,
+            started.elapsed(),
+            succeeded,
+        );
+    }
 }
 
 #[cfg(test)]
 mod refresh_tests {
     use super::{
-        grid_dims, refresh_entries, Fence, RefreshState, RefreshTimerAction,
-        REFRESH_DEBOUNCE_MS,
+        animation_progress, grid_dims, refresh_entries, Fence, RefreshState, RefreshTimerAction,
+        ANIM_DURATION, REFRESH_DEBOUNCE_MS,
     };
     use crate::config::FenceCfg;
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -553,6 +584,14 @@ mod refresh_tests {
             RefreshTimerAction::Idle
         );
         assert!(state.record_event(start + Duration::from_millis(202)));
+    }
+
+    #[test]
+    fn animation_progress_tracks_elapsed_time_and_clamps_at_the_end() {
+        assert_eq!(animation_progress(Duration::ZERO), 0.0);
+        assert_eq!(animation_progress(ANIM_DURATION / 2), 0.5);
+        assert_eq!(animation_progress(ANIM_DURATION), 1.0);
+        assert_eq!(animation_progress(ANIM_DURATION * 2), 1.0);
     }
 
     #[test]
@@ -1384,10 +1423,11 @@ unsafe extern "system" fn fence_wndproc(
                 with_global(|g| {
                     if let Some(idx) = fence_idx(g, hwnd) {
                         let f = &mut g.fences[idx];
-                        if f.animating {
-                            step_page_anim(f);
-                        }
+                        let finished = f.animating && !step_page_anim(f);
                         render_fence(&mut g.icons, g.config.ghost_mode, f);
+                        if finished {
+                            continue_perf_animation(f);
+                        }
                     }
                 });
             }
@@ -1584,17 +1624,25 @@ fn stop_page_anim(f: &mut Fence) {
     }
 }
 
-/// 翻页动画时长(帧,16ms/帧 → 约 200ms)
-const ANIM_FRAMES: u32 = 13;
+/// 翻页目标时长；按真实经过时间推进，慢帧会自然跳过中间位置。
+const ANIM_DURATION: Duration = Duration::from_millis(200);
+const ANIM_TICK_MS: u32 = 16;
+
+fn animation_progress(elapsed: Duration) -> f32 {
+    (elapsed.as_secs_f32() / ANIM_DURATION.as_secs_f32()).min(1.0)
+}
 
 /// 启动翻页动画(定时器驱动重绘):记录起始位置,固定时长 cubic ease-out
 fn start_page_anim(f: &mut Fence) {
     if !f.animating && !f.hwnd.is_invalid() {
         f.animating = true;
-        f.anim_frames = 0;
         f.anim_from = f.top_row;
+        f.anim_started = Instant::now()
+            .checked_sub(Duration::from_millis(ANIM_TICK_MS as u64))
+            .unwrap_or_else(Instant::now);
+        crate::perf::begin_animation(f.cfg.id);
         unsafe {
-            let _ = SetTimer(Some(f.hwnd), ANIM_TICK, 16, None);
+            let _ = SetTimer(Some(f.hwnd), ANIM_TICK, ANIM_TICK_MS, None);
         }
     }
 }
@@ -1604,8 +1652,7 @@ fn start_page_anim(f: &mut Fence) {
 fn step_page_anim(f: &mut Fence) -> bool {
     let (_, rows) = grid_dims(f);
     let target = f.page as f32 * rows as f32;
-    f.anim_frames += 1;
-    let t = (f.anim_frames as f32 / ANIM_FRAMES as f32).min(1.0);
+    let t = animation_progress(f.anim_started.elapsed());
     let e = 1.0 - (1.0 - t) * (1.0 - t) * (1.0 - t);
     f.top_row = f.anim_from + (target - f.anim_from) * e;
     if t >= 1.0 {
@@ -1870,6 +1917,33 @@ unsafe fn draw_outlined_text(
     unsafe { draw_text(g, font, fmt, white, text, rect) };
 }
 
+/// 动画帧采用一次阴影 + 一次正文，静止帧保留八方向描边。
+/// 滚动中的文字本就在移动，减少重复绘制能明显降低帧耗时；落点画质不变。
+unsafe fn draw_label_line(
+    g: *mut GpGraphics,
+    font: *const GpFont,
+    fmt: *const GpStringFormat,
+    shadow: *const GpBrush,
+    white: *const GpBrush,
+    text: &str,
+    rect: RectF,
+    fast: bool,
+) {
+    if fast {
+        let shadow_rect = RectF {
+            X: rect.X + 1.0,
+            Y: rect.Y + 1.0,
+            Width: rect.Width,
+            Height: rect.Height,
+        };
+        draw_text(g, font, fmt, shadow, text, shadow_rect);
+        draw_text(g, font, fmt, white, text, rect);
+    } else {
+        draw_outlined_text(g, font, fmt, shadow, white, text, rect, 1.0);
+    }
+
+}
+
 /// 文件名称:仿 Windows 桌面图标标签 —— 白色文字 + 紧实深色描边,
 /// 单行放得下就单行,放不下自动两行,末行超长由 fmt 的省略号裁剪。
 unsafe fn draw_label(
@@ -1881,6 +1955,7 @@ unsafe fn draw_label(
     white: *const GpBrush,
     text: &str,
     rect: RectF,
+    fast: bool,
 ) {
     let w = wstr(text);
     let units: Vec<u16> = text.encode_utf16().collect();
@@ -1904,9 +1979,8 @@ unsafe fn draw_label(
     }
     // 描边固定 1 物理像素:整数偏移不会二次软化字形,八方向合起来仍是纤细一圈,
     // 不随 DPI 变粗(此前 round(dpi) 在 1.5× 下取到 2px,把标签撑得又粗又糊)。
-    let stroke = 1.0_f32;
     if (fitted as usize) >= total && bbox.Width <= rect.Width + 0.5 {
-        unsafe { draw_outlined_text(g, font, fmt, shadow, white, text, rect, stroke) };
+        unsafe { draw_label_line(g, font, fmt, shadow, white, text, rect, fast) };
         return;
     }
     // 两行:第 1 行取能放下的字符数;若切点落在代理对中间(前一个码元是高代理)则前移
@@ -1923,8 +1997,8 @@ unsafe fn draw_label(
     let r1 = RectF { X: rect.X, Y: rect.Y, Width: rect.Width, Height: half };
     let r2 = RectF { X: rect.X, Y: rect.Y + half, Width: rect.Width, Height: half };
     unsafe {
-        draw_outlined_text(g, font, fmt, shadow, white, &line1, r1, stroke);
-        draw_outlined_text(g, font, fmt, shadow, white, &line2, r2, stroke);
+        draw_label_line(g, font, fmt, shadow, white, &line1, r1, fast);
+        draw_label_line(g, font, fmt, shadow, white, &line2, r2, fast);
     }
 }
 
@@ -1990,32 +2064,80 @@ pub fn render_fence(icons: &mut crate::icons::IconCache, ghost_mode: bool, f: &m
         global = (255.0 * 0.16) as u8;
     }
     // 直接绘制+提交(不走 WM_PAINT;直接用 f,不查表——创建时 fence 还没进全局列表)
-    paint_core(icons, f, bg_alpha, global);
+    if let Some(sample) = paint_core(icons, f, bg_alpha, global) {
+        crate::perf::record_render(f.cfg.id, f.animating, sample);
+    }
+}
+
+pub fn start_perf_animation(f: &mut Fence) -> bool {
+    if !crate::perf::enabled() || total_pages(f) <= 1 {
+        return false;
+    }
+    f.perf_anim_remaining = crate::perf::animation_repeats().saturating_sub(1);
+    f.page = 1;
+    start_page_anim(f);
+    step_page_anim(f);
+    true
+}
+
+fn continue_perf_animation(f: &mut Fence) -> bool {
+    if f.perf_anim_remaining == 0 {
+        return false;
+    }
+    f.perf_anim_remaining -= 1;
+    f.page = usize::from(f.page == 0);
+    start_page_anim(f);
+    true
 }
 
 /// 核心绘制:画进每栅栏缓存 DIB(GDI+ 文字/图形 + GDI 图标),预乘 alpha 后
 /// UpdateLayeredWindow 整幅提交。半透明像素真透明透出桌面,内容画满矩形,圆角由 DWM 裁。
-fn paint_core(icons: &mut crate::icons::IconCache, f: &mut Fence, bg_alpha: u8, global: u8) {
+fn paint_core(
+    icons: &mut crate::icons::IconCache,
+    f: &mut Fence,
+    bg_alpha: u8,
+    global: u8,
+) -> Option<crate::perf::RenderSample> {
     let w = f.cfg.w;
     let h = f.cfg.h;
     if w <= 0 || h <= 0 {
-        return;
+        return None;
+    }
+    let profiling = crate::perf::enabled();
+    let total_started = profiling.then(Instant::now);
+    let mut sample = crate::perf::RenderSample {
+        width: w,
+        height: h,
+        entries: f.entries.len(),
+        ..Default::default()
+    };
+    if profiling {
+        let _ = icons.take_perf_stats();
     }
     unsafe {
         // 取/建缓存 DIB(尺寸不变则复用,避免每次重建);bits 为空 = 创建失败
+        let cache_started = profiling.then(Instant::now);
         let bits = ensure_cache(f, w, h);
+        sample.ensure_cache = cache_started
+            .map(|started| started.elapsed())
+            .unwrap_or_default();
         if bits.is_null() {
-            return;
+            return None;
         }
         let memdc = match f.cache.as_ref() {
             Some(c) => c.mdc,
-            None => return,
+            None => return None,
         };
         // 整幅清成全透明(0),重画当前帧
+        let clear_started = profiling.then(Instant::now);
         std::ptr::write_bytes(bits, 0, (w as usize) * (h as usize) * 4);
+        sample.clear = clear_started
+            .map(|started| started.elapsed())
+            .unwrap_or_default();
+        let gdi_plus_started = profiling.then(Instant::now);
         let mut gfx: *mut GpGraphics = std::ptr::null_mut();
         if GdipCreateFromHDC(memdc, &mut gfx).0 != 0 {
-            return;
+            return None;
         }
         GdipSetSmoothingMode(gfx, SmoothingModeAntiAlias);
         // GridFit 把字形笔画对齐到物理像素网格,比普通灰阶抗锯齿更接近
@@ -2157,6 +2279,7 @@ fn paint_core(icons: &mut crate::icons::IconCache, f: &mut Fence, bg_alpha: u8, 
                             Width: cell_w + 4.0,
                             Height: label_h(d) as f32 - 4.0,
                         };
+                        let label_started = profiling.then(Instant::now);
                         draw_label(
                             gfx,
                             label_font,
@@ -2166,7 +2289,12 @@ fn paint_core(icons: &mut crate::icons::IconCache, f: &mut Fence, bg_alpha: u8, 
                             label_brush as *const GpBrush,
                             &e.name,
                             label_rect,
+                            f.animating,
                         );
+                        if let Some(started) = label_started {
+                            sample.label_count += 1;
+                            sample.label_time += started.elapsed();
+                        }
                     }
                 }
                 GdipResetClip(gfx);
@@ -2205,12 +2333,23 @@ fn paint_core(icons: &mut crate::icons::IconCache, f: &mut Fence, bg_alpha: u8, 
         GdipDeleteFontFamily(fam);
         GdipFlush(gfx, FlushIntentionSync);
         GdipDeleteGraphics(gfx);
+        sample.gdi_plus = gdi_plus_started
+            .map(|started| started.elapsed())
+            .unwrap_or_default();
+        if profiling {
+            let icon_stats = icons.take_perf_stats();
+            sample.icon_hits = icon_stats.hits;
+            sample.icon_misses = icon_stats.misses;
+            sample.icon_hit_time = icon_stats.hit_time;
+            sample.icon_miss_time = icon_stats.miss_time;
+        }
 
         // 图标:GDI DrawIconEx 直绘进 DIB(背景/文字已由 GDI+ 画好)。
         // DrawIconEx 对 32bpp 图标做原生 alpha 合成,对掩码图标套 AND 掩码,
         // 透明区域保持面板颜色,不再出现不透明黑块。
         // GDI 不认 GDI+ 的裁剪区,这里单独给图标套一层 GDI 裁剪区(精确网格内容区),
         // 否则翻页动画中相邻页的图标会飘进 title/margin。
+        let gdi_icons_started = profiling.then(Instant::now);
         let icol = icon(f);
         let ctop = (title_h(d) + margin(d)) as i32;
         let cbot = ctop + grid_rows.max(0) * cell_h(f);
@@ -2227,10 +2366,14 @@ fn paint_core(icons: &mut crate::icons::IconCache, f: &mut Fence, bg_alpha: u8, 
                 let _ = DrawIconEx(memdc, *ix, *iy, *hicon, icol, icol, 0, None, DI_NORMAL);
             }
         }
+        sample.gdi_icons = gdi_icons_started
+            .map(|started| started.elapsed())
+            .unwrap_or_default();
 
         // GDI+ 输出的是直通(straight)alpha,而 AlphaBlend 的 AC_SRC_ALPHA 要求
         // 颜色已按 alpha 预乘。逐像素转预乘(同时乘上 global 做幽灵淡出),否则半透明像素
         // 会被按预乘假定错误合成 → 图标透明处/圆角边缘出现色块、发暗。
+        let premultiply_started = profiling.then(Instant::now);
         let px = bits as *mut u32;
         let n = (w as usize) * (h as usize);
         let g = global as u32;
@@ -2247,11 +2390,22 @@ fn paint_core(icons: &mut crate::icons::IconCache, f: &mut Fence, bg_alpha: u8, 
             let r = (((p >> 16) & 0xFF) * a2) / 255;
             *px.add(i) = (a2 << 24) | (r << 16) | (gr << 8) | b;
         }
+        sample.premultiply = premultiply_started
+            .map(|started| started.elapsed())
+            .unwrap_or_default();
 
         // 提交:UpdateLayeredWindow 整幅替换窗口表面。透明像素透出桌面(真透明),
         // 不透明像素直接显示——没有磨砂,内容移动也不会留残影。缓存保留供重建。
+        let ulw_started = profiling.then(Instant::now);
         if let Some(c) = &f.cache {
             submit_ulw(f.hwnd, c);
         }
+        sample.update_layered_window = ulw_started
+            .map(|started| started.elapsed())
+            .unwrap_or_default();
+        sample.total = total_started
+            .map(|started| started.elapsed())
+            .unwrap_or_default();
     }
+    profiling.then_some(sample)
 }

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -5,6 +5,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::mem::size_of;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 use windows::Win32::UI::Controls::IImageList;
 use windows::Win32::UI::Shell::{
     SHGetFileInfoW, SHGetImageList, SHFILEINFOW, SHGFI_ICON, SHGFI_LARGEICON,
@@ -23,6 +24,15 @@ unsafe impl Send for IconCache {}
 pub struct IconCache {
     map: HashMap<PathBuf, HICON>,
     lru: VecDeque<PathBuf>,
+    perf: IconPerfStats,
+}
+
+#[derive(Clone, Copy, Default)]
+pub struct IconPerfStats {
+    pub hits: u64,
+    pub misses: u64,
+    pub hit_time: Duration,
+    pub miss_time: Duration,
 }
 
 /// 从系统图像列表按索引拿图标:EXTRALARGE(48)→LARGE(32) 依次尝试。
@@ -88,11 +98,17 @@ impl IconCache {
         IconCache {
             map: HashMap::new(),
             lru: VecDeque::new(),
+            perf: IconPerfStats::default(),
         }
     }
 
     pub fn get(&mut self, path: &Path) -> HICON {
+        let started = crate::perf::enabled().then(Instant::now);
         if let Some(&h) = self.map.get(path) {
+            if let Some(started) = started {
+                self.perf.hits += 1;
+                self.perf.hit_time += started.elapsed();
+            }
             return h;
         }
         let exists = path.exists();
@@ -122,6 +138,10 @@ impl IconCache {
         } else {
             hicon
         };
+        if let Some(started) = started {
+            self.perf.misses += 1;
+            self.perf.miss_time += started.elapsed();
+        }
         if hicon.is_invalid() {
             return hicon;
         }
@@ -135,6 +155,10 @@ impl IconCache {
             }
         }
         hicon
+    }
+
+    pub fn take_perf_stats(&mut self) -> IconPerfStats {
+        std::mem::take(&mut self.perf)
     }
 
     pub fn clear(&mut self) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod dragout;
 mod droptarget;
 mod fence;
 mod icons;
+mod perf;
 mod tray;
 mod utils;
 mod watcher;
@@ -425,7 +426,7 @@ fn apply_visibility(g: &mut Global) {
 }
 
 pub fn reserve_desktop_icons(g: &Global) {
-    if !g.config.desktop_avoid {
+    if !g.config.desktop_avoid || perf::safe_desktop() {
         return;
     }
     let rects: Vec<RECT> = g
@@ -1038,6 +1039,7 @@ fn dispatch_menu(cmd: u32) {
 
 fn main() {
     dlog("[main] start");
+    perf::init();
     utils::set_dpi_awareness();
     dlog("[main] dpi set");
 
@@ -1257,6 +1259,13 @@ fn main() {
             g.watchers.push(ManagedWatcher::process(watcher));
         }
         reserve_desktop_icons(g);
+        if let Some(id) = perf::animation_fence_id() {
+            if let Some(f) = g.fences.iter_mut().find(|f| f.valid && f.cfg.id == id) {
+                if fence::start_perf_animation(f) {
+                    fence::render_fence(&mut g.icons, g.config.ghost_mode, f);
+                }
+            }
+        }
     });
 
     dlog(&format!("[main] started, fences: {}", fences.len()));

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -1,0 +1,360 @@
+use std::collections::HashMap;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+use std::sync::mpsc::{self, Sender};
+use std::sync::{Mutex, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+static ENABLED: OnceLock<bool> = OnceLock::new();
+static SAFE_DESKTOP: OnceLock<bool> = OnceLock::new();
+static LOG_TX: OnceLock<Sender<String>> = OnceLock::new();
+static ANIMATIONS: OnceLock<Mutex<HashMap<u32, AnimationSession>>> = OnceLock::new();
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct RenderSample {
+    pub width: i32,
+    pub height: i32,
+    pub entries: usize,
+    pub ensure_cache: Duration,
+    pub clear: Duration,
+    pub gdi_plus: Duration,
+    pub icon_hits: u64,
+    pub icon_misses: u64,
+    pub icon_hit_time: Duration,
+    pub icon_miss_time: Duration,
+    pub label_count: u64,
+    pub label_time: Duration,
+    pub gdi_icons: Duration,
+    pub premultiply: Duration,
+    pub update_layered_window: Duration,
+    pub total: Duration,
+}
+
+struct AnimationSession {
+    started: Instant,
+    last_frame: Option<Instant>,
+    frame_times: Vec<Duration>,
+    frame_intervals: Vec<Duration>,
+    stage_totals: RenderSample,
+}
+
+impl AnimationSession {
+    fn new() -> Self {
+        Self {
+            started: Instant::now(),
+            last_frame: None,
+            frame_times: Vec::with_capacity(16),
+            frame_intervals: Vec::with_capacity(16),
+            stage_totals: RenderSample::default(),
+        }
+    }
+
+    fn push(&mut self, sample: RenderSample, now: Instant) {
+        if let Some(previous) = self.last_frame.replace(now) {
+            self.frame_intervals
+                .push(now.saturating_duration_since(previous));
+        }
+        self.frame_times.push(sample.total);
+        add_render_sample(&mut self.stage_totals, sample);
+    }
+}
+
+pub fn enabled() -> bool {
+    *ENABLED.get_or_init(|| env_flag("FEATHER_PERF"))
+}
+
+/// 性能测试时可关闭桌面图标避让，避免测试窗口改变用户真实桌面布局。
+pub fn safe_desktop() -> bool {
+    enabled() && *SAFE_DESKTOP.get_or_init(|| env_flag("FEATHER_PERF_SAFE_DESKTOP"))
+}
+
+pub fn animation_fence_id() -> Option<u32> {
+    enabled()
+        .then(|| std::env::var("FEATHER_PERF_ANIMATE_FENCE").ok())
+        .flatten()
+        .and_then(|value| value.parse().ok())
+}
+
+pub fn animation_repeats() -> u32 {
+    if !enabled() {
+        return 1;
+    }
+    std::env::var("FEATHER_PERF_ANIMATION_REPEATS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(1)
+        .clamp(1, 10)
+}
+
+pub fn init() {
+    if enabled() {
+        emit(format!(
+            "[perf][session] pid={} profiling=enabled",
+            std::process::id()
+        ));
+    }
+}
+
+pub fn begin_animation(fence_id: u32) {
+    if !enabled() {
+        return;
+    }
+    animations()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(fence_id, AnimationSession::new());
+}
+
+pub fn record_refresh(
+    fence_id: u32,
+    dir: &Path,
+    entries: usize,
+    read: Duration,
+    sort: Duration,
+    total: Duration,
+    succeeded: bool,
+) {
+    if !enabled() {
+        return;
+    }
+    emit(format!(
+        "[perf][refresh] fence={fence_id} entries={entries} read_us={} sort_us={} total_us={} ok={succeeded} dir={}",
+        micros(read),
+        micros(sort),
+        micros(total),
+        dir.display()
+    ));
+}
+
+pub fn record_render(fence_id: u32, animating: bool, sample: RenderSample) {
+    if !enabled() {
+        return;
+    }
+
+    let now = Instant::now();
+    let (completed, belongs_to_animation) = {
+        let mut sessions = animations()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(session) = sessions.get_mut(&fence_id) {
+            session.push(sample, now);
+            if animating {
+                (None, true)
+            } else {
+                (sessions.remove(&fence_id), true)
+            }
+        } else {
+            (None, false)
+        }
+    };
+
+    if let Some(session) = completed {
+        emit_animation(fence_id, session);
+    } else if !belongs_to_animation {
+        emit_render("render", fence_id, sample);
+    }
+}
+
+fn emit_render(kind: &str, fence_id: u32, sample: RenderSample) {
+    emit(format!(
+        "[perf][{kind}] fence={fence_id} size={}x{} entries={} total_us={} cpu_draw_us={} gdi_plus_wall_us={} labels={} label_us={} label_avg_us={} gdi_icons_us={} icon_hits={} icon_misses={} icon_hit_us={} icon_miss_us={} clear_us={} premultiply_us={} ulw_us={} cache_us={}",
+        sample.width,
+        sample.height,
+        sample.entries,
+        micros(sample.total),
+        micros(cpu_draw_time(sample)),
+        micros(sample.gdi_plus),
+        sample.label_count,
+        micros(sample.label_time),
+        average_for_count(sample.label_time, sample.label_count),
+        micros(sample.gdi_icons),
+        sample.icon_hits,
+        sample.icon_misses,
+        micros(sample.icon_hit_time),
+        micros(sample.icon_miss_time),
+        micros(sample.clear),
+        micros(sample.premultiply),
+        micros(sample.update_layered_window),
+        micros(sample.ensure_cache),
+    ));
+}
+
+fn emit_animation(fence_id: u32, session: AnimationSession) {
+    let frames = session.frame_times.len();
+    if frames == 0 {
+        return;
+    }
+    let total_render: Duration = session.frame_times.iter().copied().sum();
+    let over_budget = session
+        .frame_times
+        .iter()
+        .filter(|duration| **duration > Duration::from_millis(16))
+        .count();
+    let avg = total_render / frames as u32;
+    let frame_p95 = percentile(&session.frame_times, 95);
+    let frame_max = session
+        .frame_times
+        .iter()
+        .copied()
+        .max()
+        .unwrap_or_default();
+    let interval_avg = average(&session.frame_intervals);
+    let interval_p95 = percentile(&session.frame_intervals, 95);
+    let interval_max = session
+        .frame_intervals
+        .iter()
+        .copied()
+        .max()
+        .unwrap_or_default();
+    let elapsed = session.started.elapsed();
+    let stages = session.stage_totals;
+
+    emit(format!(
+        "[perf][animation] fence={fence_id} frames={frames} elapsed_ms={} frame_avg_us={} frame_p95_us={} frame_max_us={} over_16ms={} interval_avg_us={} interval_p95_us={} interval_max_us={} cpu_draw_avg_us={} gdi_plus_wall_avg_us={} labels_total={} label_avg_frame_us={} label_avg_item_us={} gdi_icons_avg_us={} icon_hits_total={} icon_miss_total={} icon_miss_avg_us={} premultiply_avg_us={} ulw_avg_us={}",
+        elapsed.as_millis(),
+        micros(avg),
+        micros(frame_p95),
+        micros(frame_max),
+        over_budget,
+        micros(interval_avg),
+        micros(interval_p95),
+        micros(interval_max),
+        micros(cpu_draw_time(stages) / frames as u32),
+        micros(stages.gdi_plus / frames as u32),
+        stages.label_count,
+        micros(stages.label_time / frames as u32),
+        average_for_count(stages.label_time, stages.label_count),
+        micros(stages.gdi_icons / frames as u32),
+        stages.icon_hits,
+        stages.icon_misses,
+        average_for_count(stages.icon_miss_time, stages.icon_misses),
+        micros(stages.premultiply / frames as u32),
+        micros(stages.update_layered_window / frames as u32),
+    ));
+}
+
+fn cpu_draw_time(sample: RenderSample) -> Duration {
+    let icon_lookup = sample.icon_hit_time + sample.icon_miss_time;
+    sample.clear
+        + sample.gdi_plus.saturating_sub(icon_lookup)
+        + sample.gdi_icons
+        + sample.premultiply
+}
+
+fn add_render_sample(total: &mut RenderSample, sample: RenderSample) {
+    total.width = sample.width;
+    total.height = sample.height;
+    total.entries = sample.entries;
+    total.ensure_cache += sample.ensure_cache;
+    total.clear += sample.clear;
+    total.gdi_plus += sample.gdi_plus;
+    total.icon_hits += sample.icon_hits;
+    total.icon_misses += sample.icon_misses;
+    total.icon_hit_time += sample.icon_hit_time;
+    total.icon_miss_time += sample.icon_miss_time;
+    total.label_count += sample.label_count;
+    total.label_time += sample.label_time;
+    total.gdi_icons += sample.gdi_icons;
+    total.premultiply += sample.premultiply;
+    total.update_layered_window += sample.update_layered_window;
+    total.total += sample.total;
+}
+
+fn average(values: &[Duration]) -> Duration {
+    if values.is_empty() {
+        Duration::default()
+    } else {
+        values.iter().copied().sum::<Duration>() / values.len() as u32
+    }
+}
+
+fn percentile(values: &[Duration], percentile: usize) -> Duration {
+    if values.is_empty() {
+        return Duration::default();
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_unstable();
+    let index = ((sorted.len() - 1) * percentile).div_ceil(100);
+    sorted[index]
+}
+
+fn average_for_count(total: Duration, count: u64) -> u128 {
+    if count == 0 {
+        0
+    } else {
+        total.as_micros() / count as u128
+    }
+}
+
+fn micros(duration: Duration) -> u128 {
+    duration.as_micros()
+}
+
+fn env_flag(name: &str) -> bool {
+    std::env::var(name).ok().is_some_and(|value| {
+        matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
+}
+
+fn animations() -> &'static Mutex<HashMap<u32, AnimationSession>> {
+    ANIMATIONS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn emit(message: String) {
+    if let Some(sender) = log_sender() {
+        let _ = sender.send(message);
+    }
+}
+
+fn log_sender() -> Option<&'static Sender<String>> {
+    if !enabled() {
+        return None;
+    }
+    Some(LOG_TX.get_or_init(|| {
+        let (tx, rx) = mpsc::channel::<String>();
+        let log_dir = crate::config::config_dir();
+        let _ = thread::Builder::new()
+            .name("feather-perf-log".into())
+            .spawn(move || {
+                let _ = std::fs::create_dir_all(&log_dir);
+                let path = log_dir.join("perf.log");
+                let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) else {
+                    return;
+                };
+                for message in rx {
+                    let timestamp = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_millis();
+                    let _ = writeln!(file, "{timestamp} {message}");
+                }
+            });
+        tx
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{average, percentile};
+    use std::time::Duration;
+
+    #[test]
+    fn percentile_uses_nearest_rank_and_handles_empty_input() {
+        let values = [1, 2, 3, 4, 100].map(Duration::from_millis);
+        assert_eq!(percentile(&values, 95), Duration::from_millis(100));
+        assert_eq!(percentile(&values, 50), Duration::from_millis(3));
+        assert_eq!(percentile(&[], 95), Duration::default());
+    }
+
+    #[test]
+    fn average_handles_empty_input() {
+        let values = [Duration::from_millis(2), Duration::from_millis(4)];
+        assert_eq!(average(&values), Duration::from_millis(3));
+        assert_eq!(average(&[]), Duration::default());
+    }
+}


### PR DESCRIPTION
## 背景

栅栏翻页会逐帧完整重绘。分阶段测量显示，500 条目栅栏优化前平均帧耗时约 27.48 ms，动画实际持续约 396.5 ms；主要耗时在文字标签绘制，而不是目录排序或 `UpdateLayeredWindow`。

## 改动

- 增加默认关闭、通过 `FEATHER_PERF=1` 启用的渲染性能测量，记录目录读取/排序、图标缓存、GDI+ 绘制、预乘 Alpha、整窗提交和动画帧统计。
- 动画进行时将每行文字从 8 个方向描边加正文（9 次 `DrawString`）精简为阴影加正文（2 次）；动画停止后仍使用原来的高质量描边，静止画质不变。
- 翻页进度由固定 13 帧改为按真实时间计算，目标时长约 200 ms；慢帧会跳过中间进度，不再把整段动画拖长。
- 提供隔离的性能测试开关，便于使用独立配置和关闭桌面图标占位，不影响默认运行行为。

## 测量结果

| 场景 | 优化前平均帧 | 优化后暖缓存平均帧 | 优化前动画时长 | 优化后动画时长 | 超过 16 ms 的帧 |
| --- | ---: | ---: | ---: | ---: | ---: |
| 500 条目 | 27.48 ms | 10.97–11.16 ms | 396.5 ms | 212–231 ms | 13/13 → 1/8–9 |
| 1000 条目 | 29.44 ms | 11.76–12.03 ms | 约 400 ms | 212–215 ms | 13/13 → 1/8 |

最后一帧会恢复静止状态的高质量文字描边，因此仍可能出现一帧超过 16 ms。首次打开时的图标提取仍是下一个独立瓶颈，本 PR 暂不扩大范围处理。

## 影响

翻页动画更接近固定的 200 ms，暖缓存场景平均帧耗时降低约 57%–60%。未开启性能环境变量时不会写入性能日志。

## 验证

- `RUSTFLAGS="-D warnings" cargo test --locked`：12 项测试全部通过。
- `RUSTFLAGS="-D warnings" cargo build --release --locked`：通过。
- Windows 本机手动测试 500 条目栅栏：快速/慢速翻页流畅，移动中文字可接受，停止后高质量描边正常恢复。
- 已变基到 `v0.1.3`，保留新增的桌面图标避让逻辑；性能隔离模式与其开关共同生效。
