### PR TITLE
feat: 支持右键调整栅栏标题字号

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,10 @@ fn default_title_font_size() -> u32 {
     12
 }
 
+pub fn normalize_title_font_size(value: u32) -> u32 {
+    value.clamp(10, 32)
+}
+
 fn default_true() -> bool {
     true
 }
@@ -206,6 +210,13 @@ mod dpi_tests {
         assert!(c.download_enabled);
         assert!(c.download_box_visible);
         assert_eq!(c.title_font_size, 12);
+    }
+
+    #[test]
+    fn title_font_size_is_clamped_to_supported_bounds() {
+        assert_eq!(normalize_title_font_size(0), 10);
+        assert_eq!(normalize_title_font_size(18), 18);
+        assert_eq!(normalize_title_font_size(100), 32);
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,10 @@ fn default_icon() -> u32 {
     32
 }
 
+fn default_title_font_size() -> u32 {
+    12
+}
+
 fn default_true() -> bool {
     true
 }
@@ -83,6 +87,9 @@ pub struct Config {
     /// 全局图标尺寸(逻辑像素,默认 32)
     #[serde(default = "default_icon")]
     pub icon: u32,
+    /// 全局栅栏标题字号(逻辑像素,默认 12)
+    #[serde(default = "default_title_font_size")]
+    pub title_font_size: u32,
     /// 配置格式版本:
     /// - 缺省/1:旧版物理 x/y/w/h,未记录 DPI
     /// - 2:逻辑 x/y/w/h,启动时统一乘系统 DPI
@@ -107,6 +114,7 @@ impl Default for Config {
             download_enabled: true,
             download_box_visible: true,
             icon: default_icon(),
+            title_font_size: default_title_font_size(),
             desktop_avoid: false,
             version: 3,
         }
@@ -197,6 +205,7 @@ mod dpi_tests {
         let c: Config = serde_json::from_str("{}").unwrap();
         assert!(c.download_enabled);
         assert!(c.download_box_visible);
+        assert_eq!(c.title_font_size, 12);
     }
 }
 

--- a/src/fence.rs
+++ b/src/fence.rs
@@ -95,7 +95,7 @@ pub fn window_dpi(hwnd: HWND) -> f32 {
     unsafe { windows::Win32::UI::HiDpi::GetDpiForWindow(hwnd) as f32 / 96.0 }.max(1.0)
 }
 pub fn title_h(d: f32) -> i32 {
-    (30.0 * d) as i32
+    ((TITLE_FONT_PX.load(AtomicOrdering::Relaxed) as f32 + 18.0) * d).round() as i32
 }
 fn edge(d: f32) -> i32 {
     (8.0 * d) as i32
@@ -109,9 +109,15 @@ fn rail(d: f32) -> i32 {
 }
 /// 全局图标尺寸(逻辑像素):所有栅栏统一
 static ICON_PX: AtomicU32 = AtomicU32::new(32);
+/// 全局栅栏标题字号(逻辑像素):所有栅栏统一
+static TITLE_FONT_PX: AtomicU32 = AtomicU32::new(12);
 /// 设置全局图标尺寸(物理显示时再乘 DPI)
 pub fn set_icon_px(v: u32) {
     ICON_PX.store(v.max(16).min(128), AtomicOrdering::Relaxed);
+}
+/// 设置全局栅栏标题字号(物理显示时再乘 DPI)
+pub fn set_title_font_px(v: u32) {
+    TITLE_FONT_PX.store(v.clamp(10, 32), AtomicOrdering::Relaxed);
 }
 /// 图标尺寸(物理像素,按所在屏 DPI 缩放);取全局值,0 时回退 32
 fn icon(f: &Fence) -> i32 {
@@ -136,7 +142,7 @@ pub fn min_h(d: f32) -> i32 {
     (100.0 * d) as i32
 }
 fn font_title(d: f32) -> f32 {
-    11.5 * d
+    TITLE_FONT_PX.load(AtomicOrdering::Relaxed) as f32 * d
 }
 fn font_label(d: f32) -> f32 {
     // Windows 桌面图标的标签字号:9pt = 12px(逻辑像素,随 DPI 缩放)
@@ -684,6 +690,35 @@ pub fn fence_menu(hwnd: HWND) {
             );
         }
         let _ = AppendMenuW(menu, MF_POPUP, icon_menu.0 as usize, PCWSTR(w!("图标大小").as_ptr()));
+        // 标题字号子菜单(全局统一)
+        let cur_title_font = with_global(|g| g.config.title_font_size.max(1));
+        let title_font_menu = CreatePopupMenu().unwrap_or_default();
+        for (id, size) in [
+            (1013u32, 12u32),
+            (1014, 14),
+            (1015, 16),
+            (1016, 18),
+            (1017, 20),
+            (1018, 24),
+        ] {
+            let flags = if cur_title_font == size {
+                MF_STRING | MF_CHECKED
+            } else {
+                MF_STRING
+            };
+            let _ = AppendMenuW(
+                title_font_menu,
+                flags,
+                id as usize,
+                PCWSTR(wstr(&format!("{} px", size)).as_ptr()),
+            );
+        }
+        let _ = AppendMenuW(
+            menu,
+            MF_POPUP,
+            title_font_menu.0 as usize,
+            PCWSTR(w!("标题字号").as_ptr()),
+        );
         let mut pt = POINT::default();
         let _ = GetCursorPos(&mut pt);
         let cmd = TrackPopupMenu(
@@ -754,6 +789,24 @@ pub fn fence_menu(hwnd: HWND) {
                 set_icon_px(size);
                 g.config.icon = size;
                 // 图标尺寸变化 → 网格槽位/页数全变:所有栅栏重新吸附到新网格
+                let n = g.fences.len();
+                for i in 0..n {
+                    settle_fence(g, i);
+                }
+            });
+        } else if (1013..=1018).contains(&cmd) {
+            let size = match cmd {
+                1013 => 12,
+                1014 => 14,
+                1015 => 16,
+                1016 => 18,
+                1017 => 20,
+                _ => 24,
+            };
+            with_global(|g| {
+                set_title_font_px(size);
+                g.config.title_font_size = size;
+                // 标题栏高度随字号变化;重新吸附可保留完整图标行并避免文字被裁切。
                 let n = g.fences.len();
                 for i in 0..n {
                     settle_fence(g, i);

--- a/src/main.rs
+++ b/src/main.rs
@@ -990,6 +990,7 @@ fn dispatch_menu(cmd: u32) {
             with_global(|g| {
                 let mut c = config::load();
                 config::normalize_dpi(&mut c);
+                c.title_font_size = config::normalize_title_font_size(c.title_font_size);
                 fence::set_icon_px(c.icon);
                 fence::set_title_font_px(c.title_font_size);
                 g.config = c;
@@ -1136,6 +1137,7 @@ fn main() {
             .map(|f| f.icon)
             .unwrap_or(32);
     }
+    cfg.title_font_size = config::normalize_title_font_size(cfg.title_font_size);
     fence::set_icon_px(cfg.icon);
     fence::set_title_font_px(cfg.title_font_size);
     let vault = config::vault_dir(&cfg);

--- a/src/main.rs
+++ b/src/main.rs
@@ -990,6 +990,8 @@ fn dispatch_menu(cmd: u32) {
             with_global(|g| {
                 let mut c = config::load();
                 config::normalize_dpi(&mut c);
+                fence::set_icon_px(c.icon);
+                fence::set_title_font_px(c.title_font_size);
                 g.config = c;
                 // 保留进程级监听（桌面清扫和 Downloads 接管）；先停止所有栅栏监听，
                 // 避免窗口销毁期间仍收到刷新。
@@ -1135,6 +1137,7 @@ fn main() {
             .unwrap_or(32);
     }
     fence::set_icon_px(cfg.icon);
+    fence::set_title_font_px(cfg.title_font_size);
     let vault = config::vault_dir(&cfg);
     let _ = std::fs::create_dir_all(&vault);
 


### PR DESCRIPTION
## 改动说明

- 在栅栏右键菜单中新增“标题字号”子菜单，支持 12 / 14 / 16 / 18 / 20 / 24 px。
- 字号作为全局配置持久化，旧配置缺少字段时保持原有 12 px 显示。
- 字号切换后立即应用到所有栅栏，并联动标题栏高度与网格吸附，避免标题裁切或压住图标。
- 重新加载配置时同步刷新图标大小和标题字号。

## 测试

- `cargo test --locked`（9 passed）
- `cargo build --release --locked`

这个优化来自实际使用时标题文字偏小的需求。