### PR TITLE
fix: 保持拖放的移动与复制语义

### DIFF
--- a/src/dragout.rs
+++ b/src/dragout.rs
@@ -5,6 +5,8 @@
 // drop target 接住(文件已在自身目录则跳过 → 无操作)。
 use std::cell::Cell;
 use std::mem::size_of;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
 
 use windows::core::{implement, Error, Ref, Result, BOOL, HRESULT};
 use windows::Win32::Foundation::{
@@ -19,19 +21,34 @@ use windows::Win32::System::DataExchange::RegisterClipboardFormatW;
 use windows::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GHND};
 use windows::Win32::System::Ole::{
     DoDragDrop, IDropSource, IDropSource_Impl, CF_HDROP, DROPEFFECT, DROPEFFECT_COPY,
-    DROPEFFECT_MOVE, DROPEFFECT_NONE,
+    DROPEFFECT_MOVE, DROPEFFECT_NONE, ReleaseStgMedium,
 };
 use windows::Win32::System::SystemServices::{MK_LBUTTON, MODIFIERKEYS_FLAGS};
-use windows::Win32::UI::Shell::{CFSTR_PREFERREDDROPEFFECT, DROPFILES};
+use windows::Win32::UI::Shell::{CFSTR_PERFORMEDDROPEFFECT, DROPFILES};
 
 /// DATA_E_FORMATETC:请求的格式不是 CF_HDROP
 const DATA_E_FORMATETC: HRESULT = HRESULT(0x80040064_u32 as _);
+
+fn final_drop_effect(ole_effect: DROPEFFECT, shell_reported: u32) -> DROPEFFECT {
+    let allowed = DROPEFFECT_COPY.0 | DROPEFFECT_MOVE.0;
+    let bits = if shell_reported & allowed != 0 {
+        shell_reported
+    } else {
+        ole_effect.0
+    };
+    DROPEFFECT(bits & allowed)
+}
 
 /// 拖出指定路径:阻塞到拖拽结束。返回实际拖放效果(MOVE/COPY/NONE)。
 pub fn start_drag(paths: Vec<String>) -> DROPEFFECT {
     crate::dlog(&format!("[dragout] start drag: {}", paths.join("; ")));
     unsafe {
-        let dataobj: IDataObject = FileDataObject { paths }.into();
+        let performed_effect = Arc::new(AtomicU32::new(DROPEFFECT_NONE.0));
+        let dataobj: IDataObject = FileDataObject {
+            paths,
+            performed_effect: Arc::clone(&performed_effect),
+        }
+        .into();
         let src: IDropSource = FileDropSource.into();
         let mut effect = DROPEFFECT_NONE;
         let hr = DoDragDrop(
@@ -41,11 +58,23 @@ pub fn start_drag(paths: Vec<String>) -> DROPEFFECT {
             &mut effect,
         );
         // 诊断:hr 里能看到 E_UNEXPECTED/CO_E_* 等失败原因;effect 为 NONE 表示目标拒绝。
+        let shell_reported = performed_effect.load(Ordering::Relaxed);
+        let final_effect = final_drop_effect(effect, shell_reported);
+        let name = if final_effect.0 & DROPEFFECT_COPY.0 != 0 {
+            "copy"
+        } else if final_effect.0 & DROPEFFECT_MOVE.0 != 0 {
+            "move"
+        } else {
+            "none"
+        };
         crate::dlog(&format!(
-            "[dragout] DoDragDrop hr=0x{:08x} effect={}",
-            hr.0 as u32, effect.0
+            "[dragout] DoDragDrop hr=0x{:08x} effect={} performed={} final={}",
+            hr.0 as u32,
+            effect.0,
+            shell_reported,
+            name
         ));
-        effect
+        final_effect
     }
 }
 
@@ -55,6 +84,8 @@ pub fn start_drag(paths: Vec<String>) -> DROPEFFECT {
 pub struct FileDataObject {
     /// 拖出的绝对路径
     pub paths: Vec<String>,
+    /// Explorer 可通过 CFSTR_PERFORMEDDROPEFFECT 回写真正执行的 COPY/MOVE。
+    performed_effect: Arc<AtomicU32>,
 }
 
 /// 构造 CF_HDROP 全局内存块:DROPFILES 头 + 宽字符路径序列(每段 0 结尾,整体双 0 结尾)。
@@ -94,19 +125,6 @@ unsafe fn build_hdrop(paths: &[String]) -> Result<HGLOBAL> {
     Ok(hg)
 }
 
-/// 构造 Shell 拖放效果格式要求的 DWORD 全局内存块。
-unsafe fn build_drop_effect(effect: DROPEFFECT) -> Result<HGLOBAL> {
-    let hg = GlobalAlloc(GHND, size_of::<u32>())?;
-    let ptr = GlobalLock(hg);
-    if ptr.is_null() {
-        let _ = GlobalFree(Some(hg));
-        return Err(Error::from_hresult(E_UNEXPECTED));
-    }
-    std::ptr::write_unaligned(ptr as *mut u32, effect.0);
-    let _ = GlobalUnlock(hg);
-    Ok(hg)
-}
-
 /// 文件路径格式:CF_HDROP / DVASPECT_CONTENT / TYMED_HGLOBAL / lindex=-1。
 /// GetData/QueryGetData/EnumFormatEtc 三处必须用同一格式描述,否则目标会格式不匹配而拒绝。
 fn hdrop_format() -> FORMATETC {
@@ -119,10 +137,9 @@ fn hdrop_format() -> FORMATETC {
     }
 }
 
-/// 告诉 Explorer：从栅栏正常拖出时首选“移动”。用户按住 Ctrl 时，目标仍可选择“复制”。
-fn preferred_drop_effect_format() -> FORMATETC {
+fn performed_drop_effect_format() -> FORMATETC {
     FORMATETC {
-        cfFormat: unsafe { RegisterClipboardFormatW(CFSTR_PREFERREDDROPEFFECT) as u16 },
+        cfFormat: unsafe { RegisterClipboardFormatW(CFSTR_PERFORMEDDROPEFFECT) as u16 },
         ptd: std::ptr::null_mut(),
         dwAspect: DVASPECT_CONTENT.0 as u32,
         lindex: -1,
@@ -130,11 +147,19 @@ fn preferred_drop_effect_format() -> FORMATETC {
     }
 }
 
-fn format_at(pos: u32) -> Option<FORMATETC> {
-    match pos {
-        0 => Some(hdrop_format()),
-        1 => Some(preferred_drop_effect_format()),
+fn format_at(direction: u32, pos: u32) -> Option<FORMATETC> {
+    match (direction, pos) {
+        (1, 0) => Some(hdrop_format()),
+        (2, 0) => Some(performed_drop_effect_format()),
         _ => None,
+    }
+}
+
+fn format_count(direction: u32) -> u32 {
+    match direction {
+        1 => 1,
+        2 => 1,
+        _ => 0,
     }
 }
 
@@ -145,7 +170,14 @@ fn is_supported_get_format(fmt: &FORMATETC) -> bool {
     {
         return false;
     }
-    fmt.cfFormat == CF_HDROP.0 || fmt.cfFormat == preferred_drop_effect_format().cfFormat
+    fmt.cfFormat == CF_HDROP.0
+}
+
+fn is_supported_set_format(fmt: &FORMATETC) -> bool {
+    fmt.dwAspect == DVASPECT_CONTENT.0 as u32
+        && fmt.lindex == -1
+        && fmt.tymed & TYMED_HGLOBAL.0 as u32 != 0
+        && fmt.cfFormat == performed_drop_effect_format().cfFormat
 }
 
 /// 可读格式枚举：CF_HDROP 文件路径 + Preferred DropEffect 首选移动。
@@ -155,6 +187,8 @@ fn is_supported_get_format(fmt: &FORMATETC) -> bool {
 pub struct FileFormatEnum {
     /// 枚举游标(0..=1);Cell 以支持 &self 上推进游标
     pos: Cell<u32>,
+    /// DATADIR_GET=1 或 DATADIR_SET=2。
+    direction: u32,
 }
 
 impl IEnumFORMATETC_Impl for FileFormatEnum_Impl {
@@ -165,7 +199,7 @@ impl IEnumFORMATETC_Impl for FileFormatEnum_Impl {
             }
             let mut n = 0u32;
             while n < celt {
-                let Some(fmt) = format_at(self.pos.get()) else {
+                let Some(fmt) = format_at(self.direction, self.pos.get()) else {
                     break;
                 };
                 *rgelt.add(n as usize) = fmt;
@@ -185,7 +219,7 @@ impl IEnumFORMATETC_Impl for FileFormatEnum_Impl {
     }
 
     fn Skip(&self, celt: u32) -> Result<()> {
-        let remain = 2u32.saturating_sub(self.pos.get());
+        let remain = format_count(self.direction).saturating_sub(self.pos.get());
         let skipped = remain.min(celt);
         self.pos.set(self.pos.get() + skipped);
         if skipped == celt {
@@ -204,6 +238,7 @@ impl IEnumFORMATETC_Impl for FileFormatEnum_Impl {
     fn Clone(&self) -> Result<IEnumFORMATETC> {
         let e: IEnumFORMATETC = FileFormatEnum {
             pos: Cell::new(self.pos.get()),
+            direction: self.direction,
         }
         .into();
         Ok(e)
@@ -220,11 +255,7 @@ impl IDataObject_Impl for FileDataObject_Impl {
             if !is_supported_get_format(&fmt) {
                 return Err(Error::from_hresult(DATA_E_FORMATETC));
             }
-            let hg = if fmt.cfFormat == CF_HDROP.0 {
-                build_hdrop(&self.paths)?
-            } else {
-                build_drop_effect(DROPEFFECT_MOVE)?
-            };
+            let hg = build_hdrop(&self.paths)?;
             let mut medium = STGMEDIUM::default();
             medium.tymed = TYMED_HGLOBAL.0 as u32;
             medium.u.hGlobal = hg;
@@ -260,20 +291,47 @@ impl IDataObject_Impl for FileDataObject_Impl {
 
     fn SetData(
         &self,
-        _pformatetc: *const FORMATETC,
-        _pmedium: *const STGMEDIUM,
-        _frelease: BOOL,
+        pformatetc: *const FORMATETC,
+        pmedium: *const STGMEDIUM,
+        frelease: BOOL,
     ) -> Result<()> {
-        Err(Error::from_hresult(E_NOTIMPL))
+        unsafe {
+            if pformatetc.is_null() || pmedium.is_null() {
+                return Err(Error::from_hresult(E_INVALIDARG));
+            }
+            let fmt = *pformatetc;
+            let medium = &*pmedium;
+            if !is_supported_set_format(&fmt)
+                || medium.tymed & TYMED_HGLOBAL.0 as u32 == 0
+                || medium.u.hGlobal.is_invalid()
+            {
+                return Err(Error::from_hresult(DATA_E_FORMATETC));
+            }
+            let ptr = GlobalLock(medium.u.hGlobal);
+            if ptr.is_null() {
+                return Err(Error::from_hresult(E_UNEXPECTED));
+            }
+            let effect = std::ptr::read_unaligned(ptr as *const u32);
+            let _ = GlobalUnlock(medium.u.hGlobal);
+            self.performed_effect.store(effect, Ordering::Relaxed);
+            if frelease.as_bool() {
+                ReleaseStgMedium(pmedium as *mut STGMEDIUM);
+            }
+            Ok(())
+        }
     }
 
     fn EnumFormatEtc(&self, dwdirection: u32) -> Result<IEnumFORMATETC> {
-        // DATADIR_GET = 1(读数据):返回文件路径与首选拖放效果;
-        // DATADIR_SET = 2(写数据):只读数据源不支持,返回 E_NOTIMPL(标准行为)。
-        if dwdirection != 1 {
+        // DATADIR_GET = 1:文件路径;
+        // DATADIR_SET = 2:Explorer 回写真正执行的 COPY/MOVE。
+        if format_count(dwdirection) == 0 {
             return Err(Error::from_hresult(E_NOTIMPL));
         }
-        let e: IEnumFORMATETC = FileFormatEnum { pos: Cell::new(0) }.into();
+        let e: IEnumFORMATETC = FileFormatEnum {
+            pos: Cell::new(0),
+            direction: dwdirection,
+        }
+        .into();
         Ok(e)
     }
 
@@ -300,26 +358,36 @@ mod tests {
     use super::*;
 
     #[test]
-    fn advertises_file_paths_and_move_preference() {
+    fn advertises_file_paths_and_performed_effect_feedback() {
         let paths = hdrop_format();
-        let preference = preferred_drop_effect_format();
 
-        assert_ne!(paths.cfFormat, preference.cfFormat);
         assert!(is_supported_get_format(&paths));
-        assert!(is_supported_get_format(&preference));
-        assert!(format_at(2).is_none());
+        assert!(format_at(1, 0).is_some());
+        assert!(format_at(1, 1).is_none());
+
+        let performed = performed_drop_effect_format();
+        assert!(is_supported_set_format(&performed));
+        assert!(format_at(2, 0).is_some());
+        assert!(format_at(2, 1).is_none());
     }
 
     #[test]
-    fn preferred_effect_payload_requests_move() {
-        unsafe {
-            let hg = build_drop_effect(DROPEFFECT_MOVE).unwrap();
-            let ptr = GlobalLock(hg) as *const u32;
-            assert!(!ptr.is_null());
-            assert_eq!(std::ptr::read_unaligned(ptr), DROPEFFECT_MOVE.0);
-            let _ = GlobalUnlock(hg);
-            let _ = GlobalFree(Some(hg));
-        }
+    fn outgoing_get_formats_leave_effect_choice_to_drop_target() {
+        assert_eq!(format_count(1), 1);
+        assert_eq!(format_at(1, 0).unwrap().cfFormat, CF_HDROP.0);
+        assert!(format_at(1, 1).is_none());
+    }
+
+    #[test]
+    fn explorer_performed_copy_overrides_the_ole_fallback() {
+        assert_eq!(
+            final_drop_effect(DROPEFFECT_MOVE, DROPEFFECT_COPY.0),
+            DROPEFFECT_COPY
+        );
+        assert_eq!(
+            final_drop_effect(DROPEFFECT_MOVE, DROPEFFECT_NONE.0),
+            DROPEFFECT_MOVE
+        );
     }
 }
 

--- a/src/droptarget.rs
+++ b/src/droptarget.rs
@@ -12,7 +12,7 @@ use windows::Win32::System::Ole::CF_HDROP;
 use windows::Win32::System::Ole::{
     DROPEFFECT, DROPEFFECT_COPY, DROPEFFECT_MOVE, DROPEFFECT_NONE, IDropTarget, IDropTarget_Impl,
 };
-use windows::Win32::System::SystemServices::MODIFIERKEYS_FLAGS;
+use windows::Win32::System::SystemServices::{MK_CONTROL, MODIFIERKEYS_FLAGS};
 use windows::Win32::UI::Shell::Common::ITEMIDLIST;
 use windows::Win32::UI::Shell::{DragQueryFileW, ILCombine, ILFree, SHGetPathFromIDListW, HDROP};
 
@@ -59,8 +59,10 @@ fn shellidlist_format() -> FORMATETC {
 /// 其次 COPY,都不允许则 NONE。返回值必须是 allowed 的子集,否则光标显示禁止且 Drop 不触发。
 /// 桌面拖快捷方式/含命名空间项时 allowed 常是 MOVE|LINK(0x6)——不含 COPY,若硬编码
 /// 返回 COPY 会被判非法,这正是多选拖不进去的根因。
-fn pick_effect(allowed: DROPEFFECT) -> DROPEFFECT {
-    if allowed.0 & DROPEFFECT_MOVE.0 != 0 {
+fn pick_effect(allowed: DROPEFFECT, keys: MODIFIERKEYS_FLAGS) -> DROPEFFECT {
+    if keys.contains(MK_CONTROL) && allowed.0 & DROPEFFECT_COPY.0 != 0 {
+        DROPEFFECT_COPY
+    } else if allowed.0 & DROPEFFECT_MOVE.0 != 0 {
         DROPEFFECT_MOVE
     } else if allowed.0 & DROPEFFECT_COPY.0 != 0 {
         DROPEFFECT_COPY
@@ -170,7 +172,7 @@ impl IDropTarget_Impl for FenceDropTarget_Impl {
     fn DragEnter(
         &self,
         dataobj: Ref<IDataObject>,
-        _keys: MODIFIERKEYS_FLAGS,
+        keys: MODIFIERKEYS_FLAGS,
         _pt: &POINTL,
         pdweffect: *mut DROPEFFECT,
     ) -> Result<()> {
@@ -178,7 +180,7 @@ impl IDropTarget_Impl for FenceDropTarget_Impl {
             let accepts = supports_paths(dataobj.as_ref());
             self.accepts.set(accepts);
             *pdweffect = if accepts {
-                pick_effect(*pdweffect)
+                pick_effect(*pdweffect, keys)
             } else {
                 DROPEFFECT_NONE
             };
@@ -188,13 +190,13 @@ impl IDropTarget_Impl for FenceDropTarget_Impl {
 
     fn DragOver(
         &self,
-        _keys: MODIFIERKEYS_FLAGS,
+        keys: MODIFIERKEYS_FLAGS,
         _pt: &POINTL,
         pdweffect: *mut DROPEFFECT,
     ) -> Result<()> {
         unsafe {
             *pdweffect = if self.accepts.get() {
-                pick_effect(*pdweffect)
+                pick_effect(*pdweffect, keys)
             } else {
                 DROPEFFECT_NONE
             };
@@ -210,7 +212,7 @@ impl IDropTarget_Impl for FenceDropTarget_Impl {
     fn Drop(
         &self,
         dataobj: Ref<IDataObject>,
-        _keys: MODIFIERKEYS_FLAGS,
+        keys: MODIFIERKEYS_FLAGS,
         _pt: &POINTL,
         pdweffect: *mut DROPEFFECT,
     ) -> Result<()> {
@@ -221,12 +223,39 @@ impl IDropTarget_Impl for FenceDropTarget_Impl {
                 *pdweffect = DROPEFFECT_NONE;
                 return Ok(());
             }
-            *pdweffect = if crate::handle_drop(self.hwnd, paths) {
-                DROPEFFECT_MOVE
+            let selected = pick_effect(*pdweffect, keys);
+            let copy_requested = selected == DROPEFFECT_COPY;
+            *pdweffect = if crate::handle_drop(self.hwnd, paths, copy_requested) {
+                selected
             } else {
                 DROPEFFECT_NONE
             };
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod effect_tests {
+    use super::*;
+
+    #[test]
+    fn ctrl_prefers_copy_and_plain_drag_prefers_move() {
+        let both = DROPEFFECT_COPY | DROPEFFECT_MOVE;
+
+        assert_eq!(pick_effect(both, MK_CONTROL), DROPEFFECT_COPY);
+        assert_eq!(
+            pick_effect(both, MODIFIERKEYS_FLAGS::default()),
+            DROPEFFECT_MOVE
+        );
+    }
+
+    #[test]
+    fn requested_effect_never_exceeds_source_permissions() {
+        assert_eq!(pick_effect(DROPEFFECT_MOVE, MK_CONTROL), DROPEFFECT_MOVE);
+        assert_eq!(
+            pick_effect(DROPEFFECT_COPY, MODIFIERKEYS_FLAGS::default()),
+            DROPEFFECT_COPY
+        );
     }
 }

--- a/src/fencelife.rs
+++ b/src/fencelife.rs
@@ -344,15 +344,22 @@ pub(crate) fn desktop_layer_tick(g: &mut Global) {
 }
 // ---------- 拖放处理 ----------
 
-fn format_drop_failures(target: &Path, moved: usize, failures: &[(String, String)]) -> String {
+fn format_drop_failures(
+    target: &Path,
+    succeeded: usize,
+    failures: &[(String, String)],
+    copy_requested: bool,
+) -> String {
     const MAX_DETAILS: usize = 5;
+    let operation = if copy_requested { "复制" } else { "移动" };
     let mut message = format!(
-        "有 {} 个项目未能移动到：\n{}\n\n",
+        "有 {} 个项目未能{}到：\n{}\n\n",
         failures.len(),
+        operation,
         target.display()
     );
-    if moved > 0 {
-        message.push_str(&format!("已成功移动 {moved} 个项目。\n\n"));
+    if succeeded > 0 {
+        message.push_str(&format!("已成功{operation} {succeeded} 个项目。\n\n"));
     }
     for (path, error) in failures.iter().take(MAX_DETAILS) {
         let name = Path::new(path)
@@ -368,8 +375,8 @@ fn format_drop_failures(target: &Path, moved: usize, failures: &[(String, String
     message
 }
 
-/// 处理拖入并返回是否至少移动了一个项目，供 OLE 向数据源报告真实结果。
-pub(crate) fn handle_drop(hwnd: HWND, paths: Vec<String>) -> bool {
+/// 处理拖入并返回是否至少复制/移动了一个项目，供 OLE 向数据源报告真实结果。
+pub(crate) fn handle_drop(hwnd: HWND, paths: Vec<String>, copy_requested: bool) -> bool {
     let result = with_global(|g| {
         let Some(idx) = g.fences.iter().position(|f| f.valid && f.hwnd == hwnd) else {
             return None;
@@ -387,7 +394,7 @@ pub(crate) fn handle_drop(hwnd: HWND, paths: Vec<String>) -> bool {
             }
             vault
         };
-        let mut moved = 0usize;
+        let mut succeeded = 0usize;
         let mut failures = Vec::new();
         for p in &paths {
             let src = PathBuf::from(p);
@@ -395,19 +402,27 @@ pub(crate) fn handle_drop(hwnd: HWND, paths: Vec<String>) -> bool {
                 failures.push((p.clone(), "源项目不存在或已被移动".to_string()));
                 continue;
             }
-            // 已在目标目录里则跳过
-            if src.parent().map(|d| d == target.as_path()).unwrap_or(false) {
+            // MOVE 到自身目录没有意义；COPY 到自身目录则应生成一个重名副本。
+            if !copy_requested
+                && src.parent().map(|d| d == target.as_path()).unwrap_or(false)
+            {
                 continue;
             }
-            match watcher::move_to_dir(&src, &target) {
-                Ok(_) => moved += 1,
+            let operation = if copy_requested {
+                watcher::copy_to_dir(&src, &target)
+            } else {
+                watcher::move_to_dir(&src, &target)
+            };
+            match operation {
+                Ok(_) => succeeded += 1,
                 Err(e) => {
-                    eprintln!("[feather] move {p} -> {} failed: {e}", target.display());
+                    let name = if copy_requested { "copy" } else { "move" };
+                    eprintln!("[feather] {name} {p} -> {} failed: {e}", target.display());
                     failures.push((p.clone(), e));
                 }
             }
         }
-        if moved > 0 {
+        if succeeded > 0 {
             unsafe { let _ = PostMessageW(Some(hwnd), WM_APP_DROP, WPARAM(0), LPARAM(0)); };
         }
         if !failures.is_empty() {
@@ -421,14 +436,14 @@ pub(crate) fn handle_drop(hwnd: HWND, paths: Vec<String>) -> bool {
                 ),
             );
         }
-        Some((target, moved, failures))
+        Some((target, succeeded, failures))
     });
 
-    let Some((target, moved, failures)) = result else {
+    let Some((target, succeeded, failures)) = result else {
         return false;
     };
     if !failures.is_empty() {
-        let message = format_drop_failures(&target, moved, &failures);
+        let message = format_drop_failures(&target, succeeded, &failures, copy_requested);
         let message_w = wstr(&message);
         unsafe {
             let _ = windows::Win32::UI::WindowsAndMessaging::MessageBoxW(
@@ -439,7 +454,7 @@ pub(crate) fn handle_drop(hwnd: HWND, paths: Vec<String>) -> bool {
             );
         }
     }
-    moved > 0
+    succeeded > 0
 }
 #[cfg(test)]
 mod drop_feedback_tests {
@@ -452,7 +467,7 @@ mod drop_feedback_tests {
             .map(|i| (format!("C:\\source\\file-{i}.txt"), "拒绝访问".to_string()))
             .collect();
 
-        let message = format_drop_failures(Path::new("D:\\target"), 2, &failures);
+        let message = format_drop_failures(Path::new("D:\\target"), 2, &failures, false);
 
         assert!(message.contains("有 7 个项目未能移动"));
         assert!(message.contains("已成功移动 2 个项目"));

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -400,6 +400,64 @@ fn copy_then_remove_file(
     Ok(())
 }
 
+fn copy_file_new(src: &Path, dest: &Path) -> Result<(), String> {
+    let mut source = std::fs::File::open(src).map_err(|e| e.to_string())?;
+    let mut target = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(dest)
+        .map_err(|e| e.to_string())?;
+    std::io::copy(&mut source, &mut target).map_err(|e| e.to_string())?;
+    target.sync_all().map_err(|e| e.to_string())?;
+    if let Ok(metadata) = source.metadata() {
+        std::fs::set_permissions(dest, metadata.permissions()).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+fn copy_dir_tree(src: &Path, dest: &Path) -> Result<(), String> {
+    std::fs::create_dir(dest).map_err(|e| e.to_string())?;
+    for entry in std::fs::read_dir(src).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let source = entry.path();
+        let target = dest.join(entry.file_name());
+        let kind = entry.file_type().map_err(|e| e.to_string())?;
+        if kind.is_dir() {
+            copy_dir_tree(&source, &target)?;
+        } else {
+            copy_file_new(&source, &target)?;
+        }
+    }
+    if let Ok(metadata) = std::fs::metadata(src) {
+        std::fs::set_permissions(dest, metadata.permissions()).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+/// 复制项目到目标目录，保留源项目，并像 Explorer 一样为重名目标生成新名称。
+pub fn copy_to_dir(src: &Path, dest_dir: &Path) -> Result<PathBuf, String> {
+    if !dest_dir.exists() {
+        std::fs::create_dir_all(dest_dir).map_err(|e| e.to_string())?;
+    }
+    let name = src.file_name().ok_or("no file name")?.to_os_string();
+    let dest = unique_dest(dest_dir, &name);
+    let result = if src.is_dir() {
+        copy_dir_tree(src, &dest)
+    } else {
+        copy_file_new(src, &dest)
+    };
+    if let Err(error) = result {
+        // `dest` was chosen as a unique name and created only by this copy attempt.
+        if dest.is_dir() {
+            let _ = std::fs::remove_dir_all(&dest);
+        } else {
+            let _ = std::fs::remove_file(&dest);
+        }
+        return Err(error);
+    }
+    Ok(dest)
+}
+
 /// 移动项目到目标目录（同卷 rename，跨卷文件 copy+delete），自动避免重名。
 pub fn move_to_dir(src: &Path, dest_dir: &Path) -> Result<PathBuf, String> {
     if !dest_dir.exists() {
@@ -448,7 +506,7 @@ pub fn unique_dest(dir: &Path, name: &std::ffi::OsStr) -> PathBuf {
 
 #[cfg(test)]
 mod move_tests {
-    use super::copy_then_remove_file;
+    use super::{copy_then_remove_file, copy_to_dir};
     use std::fs::OpenOptions;
     use std::io::Write;
     use std::os::windows::fs::OpenOptionsExt;
@@ -522,6 +580,25 @@ mod move_tests {
         assert!(error.contains("复制失败"));
         assert!(src.exists());
         assert_eq!(std::fs::read(&dest).unwrap(), b"existing content");
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn copy_to_dir_keeps_source_and_copies_nested_folders() {
+        let dir = test_dir();
+        let source_root = dir.join("source-root");
+        let source = source_root.join("folder");
+        let destination = dir.join("destination");
+        std::fs::create_dir_all(source.join("nested")).unwrap();
+        std::fs::write(source.join("nested").join("file.txt"), b"content").unwrap();
+
+        let copied = copy_to_dir(&source, &destination).unwrap();
+
+        assert!(source.join("nested").join("file.txt").exists());
+        assert_eq!(
+            std::fs::read(copied.join("nested").join("file.txt")).unwrap(),
+            b"content"
+        );
         std::fs::remove_dir_all(dir).unwrap();
     }
 }


### PR DESCRIPTION
## 问题
栅栏拖出文件时，目标可能实际执行 COPY，但旧数据对象只声明固定的 MOVE 偏好，导致最终效果判断不准确。栅栏内拖入也无法完整遵循 Ctrl COPY 语义。

## 修改
- 使用 `CFSTR_PERFORMEDDROPEFFECT` 读取 Explorer 实际执行的 COPY/MOVE 结果。
- 普通拖出保持 MOVE，Ctrl 拖出保持 COPY。
- 栅栏拖入根据修饰键选择 MOVE 或 COPY。
- 新增安全的文件/目录复制，保留源项目并避免覆盖目标。
- 复制失败时清理本次创建的目标副本；移动失败时保留源文件。
- 错误反馈明确区分复制和移动。

## 验证
- `cargo test --locked`：36 项通过。
- A+B 组合验证：38 项通过。
- `cargo check --locked` 通过。
- `RUSTFLAGS=-D warnings cargo build --locked --release` 通过。
- 未修改配置格式、桌面第一帧定位或启动窗口层级。

## 范围
本 PR 只处理 OLE MOVE/COPY 语义和安全文件复制，不包含桌面落点定位、性能追踪或鼠标捕获状态修复。